### PR TITLE
Add explanation of slash syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,18 @@
 					the context in which they are created and used. Two values that differ only in case should be
 					treated as identical.</p>
 			</section>
+			
+			<section id="extensions">
+				<h3>Extending Vocabulary Terms</h3>
+				
+				<p>This vocabulary currently uses the old <a href="https://schema.org/docs/old_extension.html">slash
+					extension syntax</a> employed by Schema.org until 2015. In this model, extensions of a term are
+					made by adding a slash followed by a refinement term. For example, see the <a
+						href="#braille"><code>braille</code> feature</a> for specifying specific braille codes.</p>
+				
+				<p>Authors are advised to use this extension mechanism sparingly at this time, as a future version of
+					the vocabulary may update this approach.</p>
+			</section>
 		</section>
 		<section id="accessibilityAPI">
 			<h2>The <code>accessibilityAPI</code> Property</h2>


### PR DESCRIPTION
This doesn't fully address issue #25, but provides an explanation of the slash syntax so it's not opaque why we have it in some places. Also advises not using extensions until we figure them out.

Should at least get us started.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/pull/27.html" title="Last updated on Nov 3, 2021, 3:27 PM UTC (44bd3c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/27/1a48603...44bd3c6.html" title="Last updated on Nov 3, 2021, 3:27 PM UTC (44bd3c6)">Diff</a>