### PR TITLE
Clarify longDescription is not related to longdesc

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,7 @@
 			pre,
 			code {
 				white-space: break-spaces !important;
-			}
-		</style>
+			}</style>
 	</head>
 	<body>
 		<section id="abstract">
@@ -84,8 +83,8 @@
 					taxonomy, these specific properties were developed together as part of a project to improve the
 					discoverability of accessible resources headed by Benetech and IMS Global. Many of these properties
 					were derived directly from the <a
-						href="http://www.imsglobal.org/accessibility/afav3p0pd/AfA3p0_DESinfoModel_v1p0pd.html"
-						>Global Access for All (AfA) Information Model Data Element Specification</a>.</p>
+						href="http://www.imsglobal.org/accessibility/afav3p0pd/AfA3p0_DESinfoModel_v1p0pd.html">Global
+						Access for All (AfA) Information Model Data Element Specification</a>.</p>
 
 				<p>Part of this work included defining vocabularies of recommended values for use with these properties
 					to ensure predictability for machine processing. This document represents those vocabularies.</p>
@@ -118,15 +117,15 @@
 					the context in which they are created and used. Two values that differ only in case should be
 					treated as identical.</p>
 			</section>
-			
+
 			<section id="extensions">
 				<h3>Extending Vocabulary Terms</h3>
-				
+
 				<p>This vocabulary currently uses the old <a href="https://schema.org/docs/old_extension.html">slash
-					extension syntax</a> employed by Schema.org until 2015. In this model, extensions of a term are
-					made by adding a slash followed by a refinement term. For example, see the <a
-						href="#braille"><code>braille</code> feature</a> for specifying specific braille codes.</p>
-				
+						extension syntax</a> employed by Schema.org until 2015. In this model, extensions of a term are
+					made by adding a slash followed by a refinement term. For example, see the <a href="#braille"
+							><code>braille</code> feature</a> for specifying specific braille codes.</p>
+
 				<p>Authors are advised to use this extension mechanism sparingly at this time, as a future version of
 					the vocabulary may update this approach.</p>
 			</section>
@@ -651,6 +650,13 @@
 
 						<p>Descriptions are provided for image-based visual content and/or complex structures such as
 							tables, mathematics, diagrams, and charts.</p>
+
+						<div class="note">
+							<p>Authors may set this property independent of the method they use to provide the extended
+								descriptions (i.e., it is not required to use the obsolete [[HTML]] <a
+									href="https://html.spec.whatwg.org/multipage/obsolete.html#attr-img-longdesc"
+										><code>longdesc</code> attribute</a>).</p>
+						</div>
 					</section>
 
 					<section id="mathml">
@@ -851,7 +857,7 @@
 
 			<p>The <code>accessibilitySummary</code> property is a free-form field that allows authors to describe the
 				accessible properties of the resource. As a result, it does not have an associated vocabulary.</p>
-			
+
 			<aside class="example" title="JSON-LD">
 				<pre><code>{
    "@context": "schema.org",
@@ -861,8 +867,8 @@
    &#8230;
 }</code></pre>
 			</aside>
-			
-			
+
+
 			<aside class="example" title="EPUB 3">
 				<pre><code>&lt;package &#8230;>
    &lt;metadata>
@@ -897,7 +903,7 @@
 				<p>The <a href="#accessModeSufficient"><code>accessModeSufficient</code> property</a> is designed to
 					fill this gap of understanding the combinations of modes necessary to fully consume the
 					information.</p>
-				
+
 				<aside class="example" title="JSON-LD">
 					<pre><code>{
    "@context": "schema.org",
@@ -908,7 +914,7 @@
    &#8230;
 }</code></pre>
 				</aside>
-				
+
 				<aside class="example" title="HTML and RDFa">
 					<pre><code>&lt;div
     vocab="https://schema.org"
@@ -1013,20 +1019,20 @@
 					<p>A list of single or combined <a href="#accessMode">accessModes</a> that are sufficient to
 						understand all the intellectual content of a resource.</p>
 				</blockquote>
-				
+
 				<p>Although the <a href="#accessMode">access modes</a> indicate how the information is encoded in its
 					default form, knowing the encoding only describes one possible perceptual pathway through the
-					content. For example, a book with textual and visual content will at least require an individual
-					who can read text and view images.</p>
-				
+					content. For example, a book with textual and visual content will at least require an individual who
+					can read text and view images.</p>
+
 				<p>The author of the content may provide alternatives to a specific access mode that allow the content
 					to be consumed in an alternative manner. The use of alternative text and extended descriptions, for
 					example, can allow a user who cannot perceive visual content to read all the information in textual
 					form.</p>
-				
-				<p>The list(s) of sufficient access modes provides users with the possible combinations of reading
-					modes that allow the content to be read in full.</p>
-				
+
+				<p>The list(s) of sufficient access modes provides users with the possible combinations of reading modes
+					that allow the content to be read in full.</p>
+
 				<aside class="example" title="JSON-LD">
 					<pre><code>{
    "@context": "schema.org",
@@ -1047,8 +1053,8 @@
    &#8230;
 }</code></pre>
 				</aside>
-				
-				
+
+
 				<aside class="example" title="EPUB 3">
 					<pre><code>&lt;package &#8230;>
    &lt;metadata>
@@ -1230,29 +1236,28 @@
 		</section>
 		<section id="change-log" class="appendix">
 			<h2>Change Log</h2>
-			
-			<p>Note that this change log only identifies substantive changes to the vocabulary &#8212; those that add
-				or deprecate terms, or are similarly noteworthy.</p>
-			
+
+			<p>Note that this change log only identifies substantive changes to the vocabulary &#8212; those that add or
+				deprecate terms, or are similarly noteworthy.</p>
+
 			<p>For a list of all issues addressed (typos, minor definition modifications, etc.), refer to the <a
-				href="https://github.com/w3c/a11y-discov-vocab/issues?q=is%3Aissue+is%3Aclosed"
-				>Community Group's issue tracker</a>.</p>
-			
+					href="https://github.com/w3c/a11y-discov-vocab/issues?q=is%3Aissue+is%3Aclosed">Community Group's
+					issue tracker</a>.</p>
+
 			<ul>
 				<li>No substantive changes have been made to date.</li>
 			</ul>
 		</section>
 		<section id="acknowledgments" class="appendix">
 			<h2>Acknowledgments</h2>
-			
-			<p>The editors would like to thank the <a
-				href="https://www.w3.org/community/a11y-discov-vocab/participants">Accessibility Discoverability
-				Vocabulary for Schema.org Community Group participants</a> for their ongoing input and suggestions
-				to improve this vocabulary.</p>
-			
-			<p>Additional thanks goes to the original participants of the <a
-				href="http://www.a11ymetadata.org">Accessibility Metadata Project</a> for their work bringing the
-				properties and vocabularies to reality.</p>
+
+			<p>The editors would like to thank the <a href="https://www.w3.org/community/a11y-discov-vocab/participants"
+					>Accessibility Discoverability Vocabulary for Schema.org Community Group participants</a> for their
+				ongoing input and suggestions to improve this vocabulary.</p>
+
+			<p>Additional thanks goes to the original participants of the <a href="http://www.a11ymetadata.org"
+					>Accessibility Metadata Project</a> for their work bringing the properties and vocabularies to
+				reality.</p>
 		</section>
 	</body>
 </html>


### PR DESCRIPTION
This PR adds a note that setting the value is not dependent on the method used to add the extended descriptions.

Fixes #15


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/pull/33.html" title="Last updated on Jan 26, 2022, 4:50 PM UTC (e533c45)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/33/ce13c80...e533c45.html" title="Last updated on Jan 26, 2022, 4:50 PM UTC (e533c45)">Diff</a>