### PR TITLE
Restructure features

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,30 +491,6 @@
 					<p>The adaptation terms identify provisions in the content that enable reading in alternative access
 						modes.</p>
 
-					<section id="displayTransformability">
-						<h5>displayTransformability</h5>
-
-						<p>Display properties are controllable by the user. This property can be set, for example, if
-							custom CSS style sheets can be applied to the content to control the appearance. It can also
-							be used to indicate that styling in document formats like Word and PDF can be modified.</p>
-
-						<p>This property can be modified to identify the specific display properties that allow
-							meaningful control. Modifiers should take the form of CSS property names, even if CSS is not
-							the document styling format:</p>
-
-						<ul>
-							<li><code>/font-size</code></li>
-							<li><code>/font-family</code></li>
-							<li><code>/line-height</code></li>
-							<li><code>/word-spacing</code></li>
-							<li><code>/color</code></li>
-							<li><code>/background-color</code></li>
-						</ul>
-
-						<p>Note that many CSS display properties can be modified, but not all usefully enhance the
-							accessibility (e.g., image-based content). </p>
-					</section>
-
 					<section id="alternativeText">
 						<h5>alternativeText</h5>
 
@@ -568,40 +544,50 @@
 							ruby.</p>
 					</section>
 
+					<section id="signLanguage">
+						<h5>signLanguage</h5>
+
+						<p>Sign language interpretation is available for audio and video content. The value may be
+							extended by adding an [[ISO-639]] sign language code. For example, <code>/sgn-en-us</code>
+							for American Sign Language.</p>
+					</section>
+
 					<section id="transcript">
 						<h5>transcript</h5>
 
 						<p>Indicates that a transcript of the audio content is available.</p>
 					</section>
-
-					<section id="ttsMarkup">
-						<h5>ttsMarkup</h5>
-
-						<p>One or more of [[SSML]], [[Pronunciation-Lexicon]], and [[CSS3-Speech]] properties has been
-							used to enhance text-to-speech playback quality.</p>
-					</section>
-
-					<section id="unlocked">
-						<h5>unlocked</h5>
-
-						<p>No digital rights management or other content restriction protocols have been applied to the
-							resource.</p>
-					</section>
 				</section>
 
-				<section id="playback-terms">
-					<h4>Playback Terms</h4>
+				<section id="rendering-control-terms">
+					<h4>Rendering Control Terms</h4>
 
 					<p>The playback values identify synchronized rendering and content control features.</p>
-
-					<section id="signLanguage">
-						<h5>signLanguage</h5>
-
-						<p>Synchronized sign language interpretation is available for audio and video content. The value
-							may be extended by adding an [[ISO-639]] sign language code. For example,
-								<code>/sgn-en-us</code> for American Sign Language.</p>
+					
+					<section id="displayTransformability">
+						<h5>displayTransformability</h5>
+						
+						<p>Display properties are controllable by the user. This property can be set, for example, if
+							custom CSS style sheets can be applied to the content to control the appearance. It can also
+							be used to indicate that styling in document formats like Word and PDF can be modified.</p>
+						
+						<p>This property can be modified to identify the specific display properties that allow
+							meaningful control. Modifiers should take the form of CSS property names, even if CSS is not
+							the document styling format:</p>
+						
+						<ul>
+							<li><code>/font-size</code></li>
+							<li><code>/font-family</code></li>
+							<li><code>/line-height</code></li>
+							<li><code>/word-spacing</code></li>
+							<li><code>/color</code></li>
+							<li><code>/background-color</code></li>
+						</ul>
+						
+						<p>Note that many CSS display properties can be modified, but not all usefully enhance the
+							accessibility (e.g., image-based content). </p>
 					</section>
-
+					
 					<section id="synchronizedAudioText">
 						<h5>synchronizedAudioText</h5>
 
@@ -615,6 +601,13 @@
 
 						<p>For content with timed interaction, this value indicates that the user can control the timing
 							to meet their needs (e.g., pause and reset)</p>
+					</section>
+
+					<section id="unlocked">
+						<h5>unlocked</h5>
+
+						<p>No digital rights management or other content restriction protocols have been applied to the
+							resource.</p>
 					</section>
 				</section>
 
@@ -642,6 +635,13 @@
 						<h5>MathML</h5>
 
 						<p>Identifies that mathematical equations and formulas are encoded in [[MathML]].</p>
+					</section>
+
+					<section id="ttsMarkup">
+						<h5>ttsMarkup</h5>
+
+						<p>One or more of [[SSML]], [[Pronunciation-Lexicon]], and [[CSS3-Speech]] properties has been
+							used to enhance text-to-speech playback quality.</p>
 					</section>
 				</section>
 

--- a/index.html
+++ b/index.html
@@ -52,8 +52,7 @@
 			pre,
 			code {
 				white-space: break-spaces !important;
-			}
-		</style>
+			}</style>
 	</head>
 	<body>
 		<section id="abstract">
@@ -84,8 +83,8 @@
 					taxonomy, these specific properties were developed together as part of a project to improve the
 					discoverability of accessible resources headed by Benetech and IMS Global. Many of these properties
 					were derived directly from the <a
-						href="http://www.imsglobal.org/accessibility/afav3p0pd/AfA3p0_DESinfoModel_v1p0pd.html"
-						>Global Access for All (AfA) Information Model Data Element Specification</a>.</p>
+						href="http://www.imsglobal.org/accessibility/afav3p0pd/AfA3p0_DESinfoModel_v1p0pd.html">Global
+						Access for All (AfA) Information Model Data Element Specification</a>.</p>
 
 				<p>Part of this work included defining vocabularies of recommended values for use with these properties
 					to ensure predictability for machine processing. This document represents those vocabularies.</p>
@@ -118,15 +117,15 @@
 					the context in which they are created and used. Two values that differ only in case should be
 					treated as identical.</p>
 			</section>
-			
+
 			<section id="extensions">
 				<h3>Extending Vocabulary Terms</h3>
-				
+
 				<p>This vocabulary currently uses the old <a href="https://schema.org/docs/old_extension.html">slash
-					extension syntax</a> employed by Schema.org until 2015. In this model, extensions of a term are
-					made by adding a slash followed by a refinement term. For example, see the <a
-						href="#braille"><code>braille</code> feature</a> for specifying specific braille codes.</p>
-				
+						extension syntax</a> employed by Schema.org until 2015. In this model, extensions of a term are
+					made by adding a slash followed by a refinement term. For example, see the <a href="#braille"
+							><code>braille</code> feature</a> for specifying specific braille codes.</p>
+
 				<p>Authors are advised to use this extension mechanism sparingly at this time, as a future version of
 					the vocabulary may update this approach.</p>
 			</section>
@@ -433,78 +432,11 @@
 			<section id="accessibilityFeature-vocabulary">
 				<h3>Vocabulary</h3>
 
-				<section id="transformation-terms">
-					<h4>Transformation Terms</h4>
-
-					<p>Transformation features either state how content is available in a transformed state or is set up
-						so that a user can transform it. These properties derive from <a
-							href="http://www.w3.org/TR/WCAG2/#visual-audio-contrast">WCAG 2 Success Criterion
-						1.4</a>.</p>
-
-					<section id="highContrastAudio">
-						<h5>highContrastAudio</h5>
-
-						<p>Audio content with speech in the foreground meets the contrast thresholds set out in <a
-								href="https://www.w3.org/WAI/WCAG21/Understanding/low-or-no-background-audio">WCAG
-								Success Criteria 1.4.7</a>. The requirement the audio meets can be appended, but is not
-							required:</p>
-
-						<ul>
-							<li><code>/noBackground</code> - no background noise is present</li>
-							<li><code>/reducedBackground</code> - at least 20db difference between foreground speech and
-								background noise</li>
-							<li><code>/switchableBackground</code> - background noise can be turned off (sufficient
-								contrast may not be met without doing so)</li>
-						</ul>
-					</section>
-
-					<section id="highContrastDisplay">
-						<h5>highContrastDisplay</h5>
-
-						<p>Content meets the visual contrast threshold set out in <a
-								href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced">WCAG Success
-								Criteria 1.4.6</a>.</p>
-					</section>
-
-					<section id="largePrint">
-						<h5>largePrint</h5>
-
-						<p>The content has been formatted to meet large print guidelines. The specific point size may
-							optionally be added as an extension (e.g., <code>largePrint/18</code>).</p>
-
-						<p>The property is not set if the font size can be increased. See <a
-								href="#displayTransformability"><code>displayTransformability</code></a>.</p>
-					</section>
-
-					<section id="displayTransformability">
-						<h5>displayTransformability</h5>
-
-						<p>Display properties are controllable by the user. This property can be set, for example, if
-							custom CSS style sheets can be applied to the content to control the appearance. It can also
-							be used to indicate that styling in document formats like Word and PDF can be modified.</p>
-
-						<p>This property can be modified to identify the specific display properties that allow
-							meaningful control. Modifiers should take the form of CSS property names, even if CSS is not
-							the document styling format:</p>
-
-						<ul>
-							<li><code>/font-size</code></li>
-							<li><code>/font-family</code></li>
-							<li><code>/line-height</code></li>
-							<li><code>/word-spacing</code></li>
-							<li><code>/color</code></li>
-							<li><code>/background-color</code></li>
-						</ul>
-
-						<p>Note that many CSS display properties can be modified, but not all usefully enhance the
-							accessibility (e.g., image-based content). </p>
-					</section>
-				</section>
-
 				<section id="structure-and-navigation-terms">
 					<h4>Structure and Navigation Terms</h4>
 
-					<p>The following values identify key navigation aids available with the work.</p>
+					<p>The structure and navigation term identify structuring and navigation aids that facilitate use of
+						the work.</p>
 
 					<section id="annotations">
 						<h5>annotations</h5>
@@ -553,41 +485,35 @@
 					</section>
 				</section>
 
-				<section id="content-control-terms">
-					<h4>Content Control Terms</h4>
+				<section id="adaptation-terms">
+					<h4>Adaptation Terms</h4>
 
-					<p>The following values identify aspects of the content that users can control to improve access to
-						the content. Do not confuse these control features with the accessibilityControl property, which
-						defines input methods used to control the content.</p>
+					<p>The adaptation terms identify provisions in the content that enable reading in alternative access
+						modes.</p>
 
-					<section id="synchronizedAudioText">
-						<h5>synchronizedAudioText</h5>
+					<section id="displayTransformability">
+						<h5>displayTransformability</h5>
 
-						<p>Describes a resource that offers both audio and text, with information that allows them to be
-							rendered simultaneously. The granularity of the synchronization is not specified. This term
-							is not recommended when the only material that is synchronized is the document headings.</p>
+						<p>Display properties are controllable by the user. This property can be set, for example, if
+							custom CSS style sheets can be applied to the content to control the appearance. It can also
+							be used to indicate that styling in document formats like Word and PDF can be modified.</p>
+
+						<p>This property can be modified to identify the specific display properties that allow
+							meaningful control. Modifiers should take the form of CSS property names, even if CSS is not
+							the document styling format:</p>
+
+						<ul>
+							<li><code>/font-size</code></li>
+							<li><code>/font-family</code></li>
+							<li><code>/line-height</code></li>
+							<li><code>/word-spacing</code></li>
+							<li><code>/color</code></li>
+							<li><code>/background-color</code></li>
+						</ul>
+
+						<p>Note that many CSS display properties can be modified, but not all usefully enhance the
+							accessibility (e.g., image-based content). </p>
 					</section>
-
-					<section id="timingControl">
-						<h5>timingControl</h5>
-
-						<p>For content with timed interaction, this value indicates that the user can control the timing
-							to meet their needs (e.g., pause and reset)</p>
-					</section>
-
-					<section id="unlocked">
-						<h5>unlocked</h5>
-
-						<p>No digital rights management or other content restriction protocols have been applied to the
-							resource.</p>
-					</section>
-				</section>
-
-				<section id="augmentation-terms">
-					<h4>Augmentation Terms</h4>
-
-					<p>Augmentation is the provision of intellectual content in a different access mode from its
-						source.</p>
 
 					<section id="alternativeText">
 						<h5>alternativeText</h5>
@@ -606,28 +532,10 @@
 								"<code>descriptions</code>").</p>
 					</section>
 
-					<section id="braille">
-						<h5>braille</h5>
-
-						<p>The content is in braille format, or alternatives are available in braille. This value can be
-							extended to identify the different types of braille (<code>/ASCII</code>,
-								<code>/unicode</code>, <code>/music</code>, <code>/math</code>, <code>/chemistry</code>
-							or <code>/nemeth</code>), and whether the braille is contracted or not (<code>/grade1</code>
-							and <code>/grade2</code>). Other extensions such as the code the braille conforms to can
-							also be specified.</p>
-					</section>
-
 					<section id="captions">
 						<h5>captions</h5>
 
 						<p>Indicates that synchronized captions are available for audio and video content.</p>
-					</section>
-
-					<section id="ChemML">
-						<h5>ChemML</h5>
-
-						<p>Identifies that chemical information is encoded using the <a
-								href="https://hachmannlab.github.io/chemml/">ChemML markup language</a>.</p>
 					</section>
 
 					<section id="describedMath">
@@ -639,24 +547,11 @@
 									><code>alttext</code> attribute</a> for [[MathML]] equations, or by other means.</p>
 					</section>
 
-					<section id="latex">
-						<h5>latex</h5>
-
-						<p>Identifies that mathematical equations and formulas are encoded in the <a
-								href="https://www.latex-project.org/">LaTeX typesetting system</a>.</p>
-					</section>
-
 					<section id="longDescription">
 						<h5>longDescription</h5>
 
 						<p>Descriptions are provided for image-based visual content and/or complex structures such as
 							tables, mathematics, diagrams, and charts.</p>
-					</section>
-
-					<section id="mathml">
-						<h5>MathML</h5>
-
-						<p>Identifies that mathematical equations and formulas are encoded in [[MathML]].</p>
 					</section>
 
 					<section id="rubyAnnotations">
@@ -673,12 +568,139 @@
 							ruby.</p>
 					</section>
 
+					<section id="transcript">
+						<h5>transcript</h5>
+
+						<p>Indicates that a transcript of the audio content is available.</p>
+					</section>
+
+					<section id="ttsMarkup">
+						<h5>ttsMarkup</h5>
+
+						<p>One or more of [[SSML]], [[Pronunciation-Lexicon]], and [[CSS3-Speech]] properties has been
+							used to enhance text-to-speech playback quality.</p>
+					</section>
+
+					<section id="unlocked">
+						<h5>unlocked</h5>
+
+						<p>No digital rights management or other content restriction protocols have been applied to the
+							resource.</p>
+					</section>
+				</section>
+
+				<section id="playback-terms">
+					<h4>Playback Terms</h4>
+
+					<p>The playback values identify synchronized rendering and content control features.</p>
+
 					<section id="signLanguage">
 						<h5>signLanguage</h5>
 
 						<p>Synchronized sign language interpretation is available for audio and video content. The value
 							may be extended by adding an [[ISO-639]] sign language code. For example,
 								<code>/sgn-en-us</code> for American Sign Language.</p>
+					</section>
+
+					<section id="synchronizedAudioText">
+						<h5>synchronizedAudioText</h5>
+
+						<p>Describes a resource that offers both audio and text, with information that allows them to be
+							rendered simultaneously. The granularity of the synchronization is not specified. This term
+							is not recommended when the only material that is synchronized is the document headings.</p>
+					</section>
+
+					<section id="timingControl">
+						<h5>timingControl</h5>
+
+						<p>For content with timed interaction, this value indicates that the user can control the timing
+							to meet their needs (e.g., pause and reset)</p>
+					</section>
+				</section>
+
+				<section id="specialized-markup-terms">
+					<h4>Specialized Markup Terms</h4>
+
+					<p>The specialized markup terms identify content available in specialized markup grammars. These
+						grammars typically provide users with enhanced structure and navigation capabilities.</p>
+
+					<section id="ChemML">
+						<h5>ChemML</h5>
+
+						<p>Identifies that chemical information is encoded using the <a
+								href="https://hachmannlab.github.io/chemml/">ChemML markup language</a>.</p>
+					</section>
+
+					<section id="latex">
+						<h5>latex</h5>
+
+						<p>Identifies that mathematical equations and formulas are encoded in the <a
+								href="https://www.latex-project.org/">LaTeX typesetting system</a>.</p>
+					</section>
+
+					<section id="mathml">
+						<h5>MathML</h5>
+
+						<p>Identifies that mathematical equations and formulas are encoded in [[MathML]].</p>
+					</section>
+				</section>
+
+				<section id="clarity-terms">
+					<h4>Clarity Terms</h4>
+
+					<p>The clarity terms identify ways that the content has been enhanced for improved auditory or
+						visual clarity.</p>
+
+					<section id="highContrastAudio">
+						<h5>highContrastAudio</h5>
+
+						<p>Audio content with speech in the foreground meets the contrast thresholds set out in <a
+								href="https://www.w3.org/WAI/WCAG21/Understanding/low-or-no-background-audio">WCAG
+								Success Criteria 1.4.7</a>. The requirement the audio meets can be appended, but is not
+							required:</p>
+
+						<ul>
+							<li><code>/noBackground</code> - no background noise is present</li>
+							<li><code>/reducedBackground</code> - at least 20db difference between foreground speech and
+								background noise</li>
+							<li><code>/switchableBackground</code> - background noise can be turned off (sufficient
+								contrast may not be met without doing so)</li>
+						</ul>
+					</section>
+
+					<section id="highContrastDisplay">
+						<h5>highContrastDisplay</h5>
+
+						<p>Content meets the visual contrast threshold set out in <a
+								href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced">WCAG Success
+								Criteria 1.4.6</a>.</p>
+					</section>
+
+					<section id="largePrint">
+						<h5>largePrint</h5>
+
+						<p>The content has been formatted to meet large print guidelines. The specific point size may
+							optionally be added as an extension (e.g., <code>largePrint/18</code>).</p>
+
+						<p>The property is not set if the font size can be increased. See <a
+								href="#displayTransformability"><code>displayTransformability</code></a>.</p>
+					</section>
+				</section>
+
+				<section id="tactile-terms">
+					<h4>Tactile Terms</h4>
+
+					<p>The tactile terms identify content that is available in tactile form.</p>
+
+					<section id="braille">
+						<h5>braille</h5>
+
+						<p>The content is in braille format, or alternatives are available in braille. This value can be
+							extended to identify the different types of braille (<code>/ASCII</code>,
+								<code>/unicode</code>, <code>/music</code>, <code>/math</code>, <code>/chemistry</code>
+							or <code>/nemeth</code>), and whether the braille is contracted or not (<code>/grade1</code>
+							and <code>/grade2</code>). Other extensions such as the code the braille conforms to can
+							also be specified.</p>
 					</section>
 
 					<section id="tactileGraphic">
@@ -693,19 +715,6 @@
 						<h5>tactileObject</h5>
 
 						<p>The content is a tactile 3D object, or the model to generate one is included.</p>
-					</section>
-
-					<section id="transcript">
-						<h5>transcript</h5>
-
-						<p>Indicates that a transcript of the audio content is available.</p>
-					</section>
-
-					<section id="ttsMarkup">
-						<h5>ttsMarkup</h5>
-
-						<p>One or more of [[SSML]], [[Pronunciation-Lexicon]], and [[CSS3-Speech]] properties has been
-							used to enhance text-to-speech playback quality.</p>
 					</section>
 				</section>
 
@@ -851,7 +860,7 @@
 
 			<p>The <code>accessibilitySummary</code> property is a free-form field that allows authors to describe the
 				accessible properties of the resource. As a result, it does not have an associated vocabulary.</p>
-			
+
 			<aside class="example" title="JSON-LD">
 				<pre><code>{
    "@context": "schema.org",
@@ -861,8 +870,8 @@
    &#8230;
 }</code></pre>
 			</aside>
-			
-			
+
+
 			<aside class="example" title="EPUB 3">
 				<pre><code>&lt;package &#8230;>
    &lt;metadata>
@@ -897,7 +906,7 @@
 				<p>The <a href="#accessModeSufficient"><code>accessModeSufficient</code> property</a> is designed to
 					fill this gap of understanding the combinations of modes necessary to fully consume the
 					information.</p>
-				
+
 				<aside class="example" title="JSON-LD">
 					<pre><code>{
    "@context": "schema.org",
@@ -908,7 +917,7 @@
    &#8230;
 }</code></pre>
 				</aside>
-				
+
 				<aside class="example" title="HTML and RDFa">
 					<pre><code>&lt;div
     vocab="https://schema.org"
@@ -1013,20 +1022,20 @@
 					<p>A list of single or combined <a href="#accessMode">accessModes</a> that are sufficient to
 						understand all the intellectual content of a resource.</p>
 				</blockquote>
-				
+
 				<p>Although the <a href="#accessMode">access modes</a> indicate how the information is encoded in its
 					default form, knowing the encoding only describes one possible perceptual pathway through the
-					content. For example, a book with textual and visual content will at least require an individual
-					who can read text and view images.</p>
-				
+					content. For example, a book with textual and visual content will at least require an individual who
+					can read text and view images.</p>
+
 				<p>The author of the content may provide alternatives to a specific access mode that allow the content
 					to be consumed in an alternative manner. The use of alternative text and extended descriptions, for
 					example, can allow a user who cannot perceive visual content to read all the information in textual
 					form.</p>
-				
-				<p>The list(s) of sufficient access modes provides users with the possible combinations of reading
-					modes that allow the content to be read in full.</p>
-				
+
+				<p>The list(s) of sufficient access modes provides users with the possible combinations of reading modes
+					that allow the content to be read in full.</p>
+
 				<aside class="example" title="JSON-LD">
 					<pre><code>{
    "@context": "schema.org",
@@ -1047,8 +1056,8 @@
    &#8230;
 }</code></pre>
 				</aside>
-				
-				
+
+
 				<aside class="example" title="EPUB 3">
 					<pre><code>&lt;package &#8230;>
    &lt;metadata>
@@ -1230,29 +1239,28 @@
 		</section>
 		<section id="change-log" class="appendix">
 			<h2>Change Log</h2>
-			
-			<p>Note that this change log only identifies substantive changes to the vocabulary &#8212; those that add
-				or deprecate terms, or are similarly noteworthy.</p>
-			
+
+			<p>Note that this change log only identifies substantive changes to the vocabulary &#8212; those that add or
+				deprecate terms, or are similarly noteworthy.</p>
+
 			<p>For a list of all issues addressed (typos, minor definition modifications, etc.), refer to the <a
-				href="https://github.com/w3c/a11y-discov-vocab/issues?q=is%3Aissue+is%3Aclosed"
-				>Community Group's issue tracker</a>.</p>
-			
+					href="https://github.com/w3c/a11y-discov-vocab/issues?q=is%3Aissue+is%3Aclosed">Community Group's
+					issue tracker</a>.</p>
+
 			<ul>
 				<li>No substantive changes have been made to date.</li>
 			</ul>
 		</section>
 		<section id="acknowledgments" class="appendix">
 			<h2>Acknowledgments</h2>
-			
-			<p>The editors would like to thank the <a
-				href="https://www.w3.org/community/a11y-discov-vocab/participants">Accessibility Discoverability
-				Vocabulary for Schema.org Community Group participants</a> for their ongoing input and suggestions
-				to improve this vocabulary.</p>
-			
-			<p>Additional thanks goes to the original participants of the <a
-				href="http://www.a11ymetadata.org">Accessibility Metadata Project</a> for their work bringing the
-				properties and vocabularies to reality.</p>
+
+			<p>The editors would like to thank the <a href="https://www.w3.org/community/a11y-discov-vocab/participants"
+					>Accessibility Discoverability Vocabulary for Schema.org Community Group participants</a> for their
+				ongoing input and suggestions to improve this vocabulary.</p>
+
+			<p>Additional thanks goes to the original participants of the <a href="http://www.a11ymetadata.org"
+					>Accessibility Metadata Project</a> for their work bringing the properties and vocabularies to
+				reality.</p>
 		</section>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1249,7 +1249,8 @@
 					issue tracker</a>.</p>
 
 			<ul>
-				<li>No substantive changes have been made to date.</li>
+				<li>26-Jan-2022: The accessibility features have been restructured to better organize them by purpose.
+					See <a href="https://github.com/w3c/a11y-discov-vocab/issues/10">issue 10</a>.</li>
 			</ul>
 		</section>
 		<section id="acknowledgments" class="appendix">

--- a/index.html
+++ b/index.html
@@ -562,7 +562,7 @@
 				<section id="rendering-control-terms">
 					<h4>Rendering Control Terms</h4>
 
-					<p>The rendering control values identify ways access to a resource and rendering and playback of its
+					<p>The rendering control values identify that access to a resource and rendering and playback of its
 						content can be controlled for easier reading.</p>
 
 					<section id="displayTransformability">

--- a/index.html
+++ b/index.html
@@ -562,19 +562,20 @@
 				<section id="rendering-control-terms">
 					<h4>Rendering Control Terms</h4>
 
-					<p>The playback values identify synchronized rendering and content control features.</p>
-					
+					<p>The rendering control values identify ways access to a resource and rendering and playback of its
+						content can be controlled for easier reading.</p>
+
 					<section id="displayTransformability">
 						<h5>displayTransformability</h5>
-						
+
 						<p>Display properties are controllable by the user. This property can be set, for example, if
 							custom CSS style sheets can be applied to the content to control the appearance. It can also
 							be used to indicate that styling in document formats like Word and PDF can be modified.</p>
-						
+
 						<p>This property can be modified to identify the specific display properties that allow
 							meaningful control. Modifiers should take the form of CSS property names, even if CSS is not
 							the document styling format:</p>
-						
+
 						<ul>
 							<li><code>/font-size</code></li>
 							<li><code>/font-family</code></li>
@@ -583,11 +584,11 @@
 							<li><code>/color</code></li>
 							<li><code>/background-color</code></li>
 						</ul>
-						
+
 						<p>Note that many CSS display properties can be modified, but not all usefully enhance the
 							accessibility (e.g., image-based content). </p>
 					</section>
-					
+
 					<section id="synchronizedAudioText">
 						<h5>synchronizedAudioText</h5>
 


### PR DESCRIPTION
We'll probably want to do some iterations on this, but here's my first attempt at restructuring.

The groupings in the PR are as follows:

```
- Structure and Navigation Terms
   - annotations
   - bookmarks
   - index
   - printPageNumbers
   - readingOrder
   - structuralNavigation
   - taggedPDF

- Adaptation Terms
   - alternativeText
   - audioDescription
   - captions
   - describedMath
   - longDescription
   - rubyAnnotations
   - signLanguage
   - transcript

- Rendering Control Terms
   - displayTransformability
   - synchronizedAudioText
   - timingControl
   - unlocked

- Specialized Markup Terms
   - ChemML
   - latex
   - MathML
   - ttsMarkup

- Clarity Terms
   - highContrastAudio
   - highContrastDisplay
   - largePrint

- Tactile Terms
   - braille
   - tactileGraphic
   - tactileObject

- none
```

It maybe makes the groups a bit too atomic, but I found the previously version led to trying to accommodate too many terms under headings they didn't fit all that well.

Fixes #10


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/pull/34.html" title="Last updated on Jan 26, 2022, 4:51 PM UTC (7b118b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/34/cb10f3e...7b118b1.html" title="Last updated on Jan 26, 2022, 4:51 PM UTC (7b118b1)">Diff</a>