### PR TITLE
Restore tableofcontents value for accessibilityFeature

### DIFF
--- a/index.html
+++ b/index.html
@@ -511,6 +511,13 @@
 							allowing navigation by assistive technologies.</p>
 					</section>
 
+					<section id="tableOfContents">
+						<h5>tableOfContents</h5>
+
+						<p>The work includes a table of contents that provides links to the major sections of the
+							content.</p>
+					</section>
+
 					<section id="taggedPDF">
 						<h5>taggedPDF</h5>
 
@@ -1300,6 +1307,8 @@
 					issue tracker</a>.</p>
 
 			<ul>
+				<li>07-Feb-2022: Restore the "tableOfContents" value for <code>accessibilityFeature</code>. See <a
+						href="https://github.com/w3c/a11y-discov-vocab/pull/39">pull request 39</a>.</li>
 				<li>04-Feb-2022: The <code>accessibilityAPI</code> value "ARIA" is deprecated. It is replaced by a new
 					"ARIA" value for <code>accessibilityFeature</code> for indicating the use of roles of enhanced
 					structural and landmark navigation. See <a href="https://github.com/w3c/a11y-discov-vocab/issues/4"


### PR DESCRIPTION
I just noticed that tableOfContents was not in the list of accessibility features. Going back to the wiki, it looks like it was never documented, and I used the definition sections when I ported the values over (not the list at the top).

This pull request adds it back with a basic definition.

(I didn't spot any other features in the wiki similarly without a definition.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/pull/39.html" title="Last updated on Feb 7, 2022, 2:32 PM UTC (0d5973d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/39/d9fadf5...0d5973d.html" title="Last updated on Feb 7, 2022, 2:32 PM UTC (0d5973d)">Diff</a>