### PR TITLE
Add note about the webschemas wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,8 +93,15 @@
 					properties, but it ensures that search tools, user agents and other machine intelligence can easily
 					parse and inform users of the information.</p>
 
-				<p class="note">For more information about the original project, refer to the <a
-						href="http://www.a11ymetadata.org/">Accessibility Metadata Project's web site</a>.</p>
+				<div class="note">
+					<p>The vocabulary defined in this document is a continuation of the work that was informally hosted
+						on the <a href="https://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki</a> (sometimes
+						referred to as the "version 2.0 accessibility properties"). The project was moved to a W3C
+						Community Group to better formalize the document and increase the transparency of its update
+						process.</p>
+					<p>For more information about the original project, refer to the <a
+							href="http://www.a11ymetadata.org/">Accessibility Metadata Project's web site</a>.</p>
+				</div>
 
 				<p class="note">For more information on how to use schema.org accessibility properties not covered by
 					this vocabulary, please refer to their relevant definitions in schema.org.</p>


### PR DESCRIPTION
As requested in #29, this PR adds a new paragraph about the relationship to the webschemas wiki page to the note in the background section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/pull/42.html" title="Last updated on Feb 8, 2022, 8:05 PM UTC (44ca0ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/42/a5ad75f...44ca0ea.html" title="Last updated on Feb 8, 2022, 8:05 PM UTC (44ca0ea)">Diff</a>