### PR TITLE
Update APIs and add links

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,8 +234,8 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				<section id="ARIA-deprecated">
 					<h4>ARIA (deprecated)</h4>
 
-					<p>Indicates the resource uses <a href="http://www.w3.org/TR/wai-aria/">ARIA</a> markup to improve
-						interoperability with platform APIs.</p>
+					<p>Indicates the resource uses <a href="http://www.w3.org/TR/wai-aria/">ARIA</a> [[WCAG21]] markup
+						to improve interoperability with platform APIs.</p>
 
 					<div class="note">
 						<p>The use of the ARIA value is now deprecated as ARIA is not an accessibility API. The
@@ -248,15 +248,15 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					<h4>ATK</h4>
 
 					<p>Indicates the resource is compatible with the <a href="https://gnome.pages.gitlab.gnome.org/atk/"
-							>Accessibility Toolkit (ATK) API</a> for GNOME.</p>
+							>Accessibility Toolkit (ATK) API</a> [[ATK]] for GNOME.</p>
 				</section>
 
 				<section id="AT-SPI">
 					<h4>AT-SPI</h4>
 
 					<p>Indicates the resource is compatible with the <a
-							href="https://gitlab.gnome.org/GNOME/at-spi2-core/">Assistive Technology Service Provider
-							Interface (AT-SPI) API</a> for GNOME.</p>
+							href="https://developer-old.gnome.org/libatspi/stable/">Assistive Technology Service
+							Provider Interface (AT-SPI) API</a> [[AT-SPI]] for GNOME.</p>
 				</section>
 
 				<section id="BlackberryAccessibility">
@@ -271,8 +271,8 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					<h4>iAccessible2</h4>
 
 					<p>Indicates the resource is compatible with the <a
-							href="https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">iAccessible2
-							API</a> for Windows.</p>
+							href="https://wiki.linuxfoundation.org/accessibility/iaccessible2/">iAccessible2 API</a>
+						[[IAccessible2]] for Windows.</p>
 				</section>
 
 				<section id="iOSAccessibility">
@@ -285,8 +285,8 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					<h4>JavaAccessibility</h4>
 
 					<p>Indicates the resource is compatible with the <a
-							href="https://docs.oracle.com/en/java/javase/12/docs/api/java.desktop/javax/accessibility/package-summary.html"
-							>Java Accessibility API (JAAPI)</a>.</p>
+							href="https://www.oracle.com/java/technologies/javase/desktop-accessibility.html">Java
+							Accessibility API</a> [[JAPI]].</p>
 				</section>
 
 				<section id="MacOSXAccessibility">
@@ -300,7 +300,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 
 					<p>Indicates the resource is compatible with the <a
 							href="https://docs.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-and-microsoft-active-accessibility"
-							>Microsoft Active Accessibility (MSAA) API</a> for Windows.</p>
+							>Microsoft Active Accessibility (MSAA) API</a> [[MSAA]] for Windows.</p>
 				</section>
 
 				<section id="NSAccessibility">

--- a/index.html
+++ b/index.html
@@ -226,13 +226,16 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				<section id="AndroidAccessibility">
 					<h4>AndroidAccessibility</h4>
 
-					<p>Indicates the resource is compatible with the Android Accessibility API.</p>
+					<p>Indicates the resource is compatible with the <a
+							href="http://developer.android.com/reference/android/view/accessibility/package-summary.html"
+							>Android Access API</a>.</p>
 				</section>
 
 				<section id="ARIA-deprecated">
 					<h4>ARIA (deprecated)</h4>
 
-					<p>Indicates the resource uses ARIA markup to improve interoperability with platform APIs.</p>
+					<p>Indicates the resource uses <a href="http://www.w3.org/TR/wai-aria/">ARIA</a> markup to improve
+						interoperability with platform APIs.</p>
 
 					<div class="note">
 						<p>The use of the ARIA value is now deprecated as ARIA is not an accessibility API. The
@@ -244,57 +247,78 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				<section id="ATK">
 					<h4>ATK</h4>
 
-					<p>Indicates the resource is compatible with the Accessibility Toolkit (ATK) API for GNOME.</p>
+					<p>Indicates the resource is compatible with the <a href="https://gnome.pages.gitlab.gnome.org/atk/"
+							>Accessibility Toolkit (ATK) API</a> for GNOME.</p>
 				</section>
 
 				<section id="AT-SPI">
 					<h4>AT-SPI</h4>
 
-					<p>Indicates the resource is compatible with the Assistive Technology Service Provider Interface
-						(AT-SPI) API for GNOME.</p>
+					<p>Indicates the resource is compatible with the <a
+							href="https://gitlab.gnome.org/GNOME/at-spi2-core/">Assistive Technology Service Provider
+							Interface (AT-SPI) API</a> for GNOME.</p>
 				</section>
 
 				<section id="BlackberryAccessibility">
 					<h4>BlackberryAccessibility</h4>
 
-					<p>Indicates the resource is compatible with the Blackberry Accessibility API.</p>
+					<p>Indicates the resource is compatible with the <a
+							href="https://blackberry.com/developers/docs/7.1.0api/net/rim/device/api/ui/accessibility/package-summary.html"
+							>Blackberry Accessibility API</a>.</p>
 				</section>
 
 				<section id="iAccessible2">
 					<h4>iAccessible2</h4>
 
-					<p>Indicates the resource is compatible with the iAccessible2 API for Windows.</p>
+					<p>Indicates the resource is compatible with the <a
+							href="https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">iAccessible2
+							API</a> for Windows.</p>
 				</section>
 
 				<section id="iOSAccessibility">
 					<h4>iOSAccessibility</h4>
 
-					<p>Indicates the resource is compatible with the iAccessible2 API for Apple iOS devices.</p>
+					<p>Indicates the resource is compatible with the <a
+							href="https://developer.apple.com/documentation/objectivec/nsobject/uiaccessibility"
+							>UIAccessibility API</a> for Apple iOS devices.</p>
 				</section>
 
 				<section id="JavaAccessibility">
 					<h4>JavaAccessibility</h4>
 
-					<p>Indicates the resource is compatible with the Java Accessibility API (JAAPI).</p>
+					<p>Indicates the resource is compatible with the <a
+							href="https://docs.oracle.com/en/java/javase/12/docs/api/java.desktop/javax/accessibility/package-summary.html"
+							>Java Accessibility API (JAAPI)</a>.</p>
+				</section>
+
+				<section id="macOSAccessibility">
+					<h4>macOSAccessibility</h4>
+
+					<p>Indicates the resource is compatible with the <a
+							href="https://developer.apple.com/documentation/appkit/nsaccessibility">macOS Accessibility
+							API</a>.</p>
 				</section>
 
 				<section id="MacOSXAccessibility">
-					<h4>MacOSXAccessibility</h4>
+					<h4>MacOSXAccessibility (deprecated)</h4>
 
-					<p>Indicates the resource is compatible with the iAccessible2 API for Windows.</p>
+					<p>Authors should use the <a href="#macOSAccessibility">macOSAccessibility</a> value instead.</p>
 				</section>
 
 				<section id="MSAA">
 					<h4>MSAA</h4>
 
-					<p>Indicates the resource is compatible with the Microsoft Active Accessibility (MSAA) API for
-						Windows.</p>
+					<p>Indicates the resource is compatible with the <a
+							href="https://docs.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-and-microsoft-active-accessibility"
+							>Microsoft Active Accessibility (MSAA) API</a> for Windows.</p>
 				</section>
 
 				<section id="UIAutomation">
 					<h4>UIAutomation</h4>
 
-					<p>Indicates the resource is compatible with the User Interface Automation API for Windows.</p>
+					<p>Indicates the resource is compatible with the <a
+							href="https://docs.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-and-microsoft-active-accessibility"
+							>User Interface Automation API</a> for Windows.</p>
 				</section>
 			</section>
 		</section>

--- a/index.html
+++ b/index.html
@@ -276,11 +276,9 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				</section>
 
 				<section id="iOSAccessibility">
-					<h4>iOSAccessibility</h4>
+					<h4>iOSAccessibility (deprecated)</h4>
 
-					<p>Indicates the resource is compatible with the <a
-							href="https://developer.apple.com/documentation/objectivec/nsobject/uiaccessibility"
-							>UIAccessibility API</a> for Apple iOS devices.</p>
+					<p>Authors should use the <a href="#NSAccessibility">NSAccessibility</a> value instead.</p>
 				</section>
 
 				<section id="JavaAccessibility">
@@ -291,18 +289,10 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 							>Java Accessibility API (JAAPI)</a>.</p>
 				</section>
 
-				<section id="macOSAccessibility">
-					<h4>macOSAccessibility</h4>
-
-					<p>Indicates the resource is compatible with the <a
-							href="https://developer.apple.com/documentation/appkit/nsaccessibility">macOS Accessibility
-							API</a>.</p>
-				</section>
-
 				<section id="MacOSXAccessibility">
 					<h4>MacOSXAccessibility (deprecated)</h4>
 
-					<p>Authors should use the <a href="#macOSAccessibility">macOSAccessibility</a> value instead.</p>
+					<p>Authors should use the <a href="#UIAccessibility">UIAccessibility</a> value instead.</p>
 				</section>
 
 				<section id="MSAA">
@@ -311,6 +301,22 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					<p>Indicates the resource is compatible with the <a
 							href="https://docs.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-and-microsoft-active-accessibility"
 							>Microsoft Active Accessibility (MSAA) API</a> for Windows.</p>
+				</section>
+
+				<section id="NSAccessibility">
+					<h4>NSAccessibility</h4>
+
+					<p>Indicates the resource is compatible with the <a
+							href="https://developer.apple.com/documentation/appkit/nsaccessibility">NSAccessibility
+							API</a> for Apple iOS and tvOS applications built on UIKit.</p>
+				</section>
+
+				<section id="UIAccessibility">
+					<h4>UIAccessibility</h4>
+
+					<p>Indicates the resource is compatible with the <a
+							href="https://developer.apple.com/documentation/objectivec/nsobject/uiaccessibility"
+							>UIAccessibility API</a> for macOS applications built on AppKit.</p>
 				</section>
 
 				<section id="UIAutomation">


### PR DESCRIPTION
The major change in this PR is adding "UIAccessibility" and "NSAccessibility" and deprecating "MacOSXAccessibility" and "iOSAccessibility". We can continue to discuss if this is the right approach here, but I wanted to get these changes committed.

Otherwise, it's primarily adding links to the various APIs. I had a bit of a struggle with this at times, as a lot of the original URLs used in the IMS doc are now 404s.

Fixes #45


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/pull/46.html" title="Last updated on May 26, 2022, 11:58 AM UTC (42b1f06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/46/bc4f560...42b1f06.html" title="Last updated on May 26, 2022, 11:58 AM UTC (42b1f06)">Diff</a>