### PR TITLE
Remove slash extension mechanism

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,15 +130,25 @@
 			</section>
 
 			<section id="extensions">
-				<h3>Extending Vocabulary Terms</h3>
+				<h3>Extending the Vocabulary</h3>
 
-				<p>This vocabulary currently uses the old <a href="https://schema.org/docs/old_extension.html">slash
-						extension syntax</a> employed by Schema.org until 2015. In this model, extensions of a term are
-					made by adding a slash followed by a refinement term. For example, see the <a href="#braille"
-							><code>braille</code> feature</a> for specifying specific braille codes.</p>
+				<p>To extend terms with more information, this vocabulary used to recommend the old <a
+						href="https://schema.org/docs/old_extension.html">slash extension syntax</a> employed by
+					Schema.org until 2015. In this model, extensions of a term are made by adding a slash followed by a
+					refinement term.</p>
 
-				<p>Authors are advised to use this extension mechanism sparingly at this time, as a future version of
-					the vocabulary may update this approach.</p>
+				<p>Authors are no longer recommended to use this extension mechanism, although the use of slashes is not
+					formally deprecated for backwards compatibility with existing content. The slash syntax was poorly
+					defined, especially when multiple refinements could be specified, making it difficult for machines
+					to process.</p>
+
+				<p>When a user may require more information about the characteristics of a resource (e.g., the specifics
+					of what type of <a href="#braille">braille</a> it contains), it is better to explain these in
+					human-readable terms in an <a href="#accessibilitySummary">accessibility summary</a>.</p>
+
+				<p>If a term in this vocabulary is not be expressive enough, it is now recommended to open an <a
+						href="https://github.com/w3c/a11y-discov-vocab/issues">issue in the tracker</a> to consider how
+					to improve the existing term (e.g., by renaming terms or defining more specialized cases).</p>
 			</section>
 		</section>
 		<section id="accessibilityAPI">
@@ -786,9 +796,13 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					<section id="signLanguage">
 						<h5>signLanguage</h5>
 
-						<p>Sign language interpretation is available for audio and video content. The value may be
-							extended by adding an [[ISO-639]] sign language code. For example, <code>/sgn-en-us</code>
-							for American Sign Language.</p>
+						<p>Sign language interpretation is available for audio and video content.</p>
+
+
+						<div class="note">
+							<p>Information about the sign language code used should be provided in the <a
+									href="#accessibilitySummary">accessibility summary</a>.</p>
+						</div>
 					</section>
 
 					<section id="transcript">
@@ -810,22 +824,6 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 						<p>Display properties are controllable by the user. This property can be set, for example, if
 							custom CSS style sheets can be applied to the content to control the appearance. It can also
 							be used to indicate that styling in document formats like Word and PDF can be modified.</p>
-
-						<p>This property can be modified to identify the specific display properties that allow
-							meaningful control. Modifiers should take the form of CSS property names, even if CSS is not
-							the document styling format:</p>
-
-						<ul>
-							<li><code>/font-size</code></li>
-							<li><code>/font-family</code></li>
-							<li><code>/line-height</code></li>
-							<li><code>/word-spacing</code></li>
-							<li><code>/color</code></li>
-							<li><code>/background-color</code></li>
-						</ul>
-
-						<p>Note that many CSS display properties can be modified, but not all usefully enhance the
-							accessibility (e.g., image-based content). </p>
 					</section>
 
 					<section id="synchronizedAudioText">
@@ -896,16 +894,14 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 
 						<p>Audio content with speech in the foreground meets the contrast thresholds set out in <a
 								href="https://www.w3.org/WAI/WCAG21/Understanding/low-or-no-background-audio">WCAG
-								Success Criteria 1.4.7</a>. The requirement the audio meets can be appended, but is not
-							required:</p>
+								Success Criteria 1.4.7</a>.</p>
 
-						<ul>
-							<li><code>/noBackground</code> - no background noise is present</li>
-							<li><code>/reducedBackground</code> - at least 20db difference between foreground speech and
-								background noise</li>
-							<li><code>/switchableBackground</code> - background noise can be turned off (sufficient
-								contrast may not be met without doing so)</li>
-						</ul>
+						<div class="note">
+							<p>Information about the how the audio meets the requirement should be provided in the <a
+									href="#accessibilitySummary">accessibility summary</a> (i.e., there is no background
+								noise, at least 20db difference between foreground speech and background noise, or the
+								background noise can be turned off.)</p>
+						</div>
 					</section>
 
 					<section id="highContrastDisplay">
@@ -919,11 +915,15 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					<section id="largePrint">
 						<h5>largePrint</h5>
 
-						<p>The content has been formatted to meet large print guidelines. The specific point size may
-							optionally be added as an extension (e.g., <code>largePrint/18</code>).</p>
+						<p>The content has been formatted to meet large print guidelines.</p>
 
 						<p>The property is not set if the font size can be increased. See <a
 								href="#displayTransformability"><code>displayTransformability</code></a>.</p>
+
+						<div class="note">
+							<p>Information about the type of large print (e.g., the font size) should be provided in the
+									<a href="#accessibilitySummary">accessibility summary</a>.</p>
+						</div>
 					</section>
 				</section>
 
@@ -935,12 +935,14 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					<section id="braille">
 						<h5>braille</h5>
 
-						<p>The content is in braille format, or alternatives are available in braille. This value can be
-							extended to identify the different types of braille (<code>/ASCII</code>,
-								<code>/unicode</code>, <code>/music</code>, <code>/math</code>, <code>/chemistry</code>
-							or <code>/nemeth</code>), and whether the braille is contracted or not (<code>/grade1</code>
-							and <code>/grade2</code>). Other extensions such as the code the braille conforms to can
-							also be specified.</p>
+						<p>The content is in braille format, or alternatives are available in braille.</p>
+
+
+						<div class="note">
+							<p>Information about the type of braille (e.g., ASCII, unicode, nemeth), whether the braille
+								is contracted or not, and what code the braille conforms to should be provided in the <a
+									href="#accessibilitySummary">accessibility summary</a>.</p>
+						</div>
 					</section>
 
 					<section id="tactileGraphic">
@@ -1329,7 +1331,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				<section id="colorDependent">
 					<h4>colorDependent</h4>
 
-					<p>Indicates that the resource contains information encoded in such that color perception is
+					<p>Indicates that the resource contains information encoded such that color perception is
 						necessary.</p>
 				</section>
 
@@ -1678,6 +1680,9 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 			<details open="">
 				<summary>Changes made in 2022</summary>
 				<ul>
+					<li>09-June-2022: Removed references to using the slash syntax to extend terms and recommend against
+						using the mechanism any more. See <a href="https://github.com/w3c/a11y-discov-vocab/issues/5"
+							>issue 5</a>.</li>
 					<li>09-June-2022: Deprecated the <code>bookmarks</code> feature due to its ambiguous definition. The
 							<code>tableOfContents</code> and <code>annotations</code> values are recommended in its
 						place. See <a href="https://github.com/w3c/a11y-discov-vocab/issues/5">issue 5</a>.</li>


### PR DESCRIPTION
This pull request removes the slash extension mechanism. The section about extensions is updated to explain that the values are not invalid but are no longer recommended (so we don't invalidate any existing content). If extensions are needed, the recommendation now is to open an issue to look at renaming terms or looking at adding additional more specific ones.

The terms that mentioned extending by slashes now have notes that explain to use the accessibility summary to explain the formatting specifics (e.g., the specific type of braille or large print). The one exception is the display transformability term. It no longer mentions extending, as the specific details are not important. (We may need to look at defining a profile of what it means to be display transformable in the future, though.)

If we find there is a need for a slash-like extension mechanism in the future, we can always review this again.

Fixes #11 
Fixes #14 
Fixes #25


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/pull/53.html" title="Last updated on Jun 9, 2022, 5:42 PM UTC (5b12cfe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/53/74cf06d...5b12cfe.html" title="Last updated on Jun 9, 2022, 5:42 PM UTC (5b12cfe)">Diff</a>