### PR TITLE
Add "unknown" term to features

### DIFF
--- a/index.html
+++ b/index.html
@@ -1805,14 +1805,22 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 			-->
 
 			<details open="">
-				<summary>Changes made in 2022</summary>
+				<summary>Changes made in 2023</summary>
 				<ul>
+					<li>27-Mar-2023: Add <code>unknown</code> feature for placeholder use. See <a
+							href="https://github.com/w3c/a11y-discov-vocab/issues/17">issue 17</a>.</li>
 					<li>06-Feb-2023: Add <code>pageNavigation</code> feature for indicating that a resource has a page
 						list. See <a href="https://github.com/w3c/a11y-discov-vocab/issues/6">issue 6</a>.</li>
 					<li>06-Feb-2023: Add <code>pageBreakMarkers</code> feature for indicating that a resource includes
 						static page break markers. <code>printPageNumbers</code> is retained as a synonym but no longer
 						recommended for use. See <a href="https://github.com/w3c/a11y-discov-vocab/issues/6">issue
 						6</a>.</li>
+				</ul>
+			</details>
+
+			<details>
+				<summary>Changes made in 2022</summary>
+				<ul>
 					<li>10-June-2022: Removed references to using the slash syntax to extend terms and recommend against
 						using the mechanism any more. See <a href="https://github.com/w3c/a11y-discov-vocab/issues/5"
 							>issue 5</a>.</li>

--- a/index.html
+++ b/index.html
@@ -531,8 +531,9 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				</ul>
 
 				<p>The vocabulary also includes <a href="#feature-none">the term "<code>none</code>"</a> that authors
-					can set to indicate that the resource does not contain special enhancements. This value avoids the
-					ambiguity that can arise if a resource has not been checked.</p>
+					can set to indicate that the resource does not contain special enhancements. Similarly, the term
+						"<code>unknown</code>" exists as a placeholder for marking content that authors need to
+					review.</p>
 
 				<p>The expected value of the <code>accessibilityFeature</code> property is a list of the applicable
 					features. For metadata formats incapable of expressing lists, the property should be repeated for
@@ -1016,6 +1017,15 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					<p>Indicates that the resource does not contain any accessibility features.</p>
 
 					<p>The <code>none</code> value must not be set with any other feature value.</p>
+				</section>
+
+				<section id="feature-unknown">
+					<h5>unknown</h5>
+
+					<p>Indicates that the author has not yet checked if the resource contains accessibility features.
+						This value is only intended as a placeholder until an accessibility review can be completed.</p>
+
+					<p>The <code>unknown</code> value must not be set with any other feature value.</p>
 				</section>
 			</section>
 		</section>


### PR DESCRIPTION
I've added a description for the term describing it as a placeholder, since the assumption with it has to be that a review hasn't been done.

I'm going to open a pull request for the epub techniques to clarifying this value and none do not meet the reporting requirements for accessibilityFeature.