### PR TITLE
Add FuchsiaAccessibility to api values

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,6 +292,14 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					</div>
 				</section>
 
+				<section id="FuchsiaAccessibility">
+					<h4>FuchsiaAccessibility</h4>
+					
+					<p>Indicates the resource is compatible with the <a
+						href="https://fuchsia.dev/fuchsia-src/concepts/accessibility/accessibility_framework"
+						>Fuchsia Accessibility Framework</a>.</p>
+				</section>
+				
 				<section id="iAccessible2">
 					<h4>iAccessible2</h4>
 
@@ -1809,6 +1817,8 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 			<details open="">
 				<summary>Changes made in 2023</summary>
 				<ul>
+					<li>05-May-2023: Add <code>FuchsiaAccessibility</code> to the <code>accessibilityAPI</code>
+						values. See <a href="https://github.com/w3c/a11y-discov-vocab/issues/24">issue 24</a>.</li>
 					<li>27-Mar-2023: Add <code>unknown</code> feature for placeholder use. See <a
 							href="https://github.com/w3c/a11y-discov-vocab/issues/17">issue 17</a>.</li>
 					<li>06-Feb-2023: Add <code>pageNavigation</code> feature for indicating that a resource has a page


### PR DESCRIPTION
Despite my last comment in issue #24, it probably makes more sense to use `FuchsiaAccessibility` and leave it to the description to link to the definition. Whether it's "Accessibility Manager" or some other API name in the future won't require changing the value.

Fixes #24


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/pull/72.html" title="Last updated on May 5, 2023, 6:06 PM UTC (6daaa9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/72/04fd591...6daaa9c.html" title="Last updated on May 5, 2023, 6:06 PM UTC (6daaa9c)">Diff</a>