### PR TITLE
Remove slash syntax from example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1717,7 +1717,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
    &lt;meta itemprop="accessibilityFeature" content="ARIA" />
    &lt;meta itemprop="accessibilityFeature" content="largePrint" />
    &lt;meta itemprop="accessibilityFeature" content="highContrastDisplay" />
-   &lt;meta itemprop="accessibilityFeature" content="displayTransformability/resizeText" />
+   &lt;meta itemprop="accessibilityFeature" content="displayTransformability" />
    &lt;meta itemprop="accessibilityFeature" content="longDescription" />
    &lt;meta itemprop="accessibilityFeature" content="alternativeText" />
    &lt;meta itemprop="accessibilityFeature" content="readingOrder" />


### PR DESCRIPTION
Removes "/resizeText" from the example.

Fixes #73


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/pull/90.html" title="Last updated on Jul 14, 2023, 3:11 PM UTC (941e50a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/90/1f217dc...941e50a.html" title="Last updated on Jul 14, 2023, 3:11 PM UTC (941e50a)">Diff</a>