### PR TITLE
updated how to handle conformsTo

### DIFF
--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -147,9 +147,9 @@
 					</tr>
 					<tr>
 						<td>
-							<p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-										><code>dcterms:conformsTo</code></a> with the URL
-									<code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</code></p>
+                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                <code>EPUB Accessibility 1.0 - WCAG 2.0 Level A</code></p>
 						</td>
 						<td>
 							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 02</a>: EPUB Accessibility
@@ -158,15 +158,123 @@
 					</tr>
 					<tr>
 						<td>
-							<p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-										><code>dcterms:conformsTo</code></a> with the URL
-									<code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa</code></p>
+                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+                                  ><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                <code>EPUB Accessibility 1.0 - WCAG 2.0 Level AA</code></p>
 						</td>
 						<td>
 							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 03</a>: EPUB Accessibility
 								Specification 1.0 AA</p>
 						</td>
 					</tr>
+	                <tr>
+						<td>
+                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                <code>EPUB Accessibility 1.1 - WCAG 2.0 Level A</code></p>
+						</td>
+						<td>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 80</a>: WCAG v2.0</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 84</a>: WCAG level A</p>                            
+						</td>
+					</tr>  
+	                <tr>
+						<td>
+                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                <code>EPUB Accessibility 1.1 - WCAG 2.0 Level AA</code></p>
+						</td>
+						<td>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 80</a>: WCAG v2.0</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 85</a>: WCAG level AA</p>                            
+						</td>
+					</tr>                    
+	                <tr>
+						<td>
+                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                <code>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</code></p>
+						</td>
+						<td>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 80</a>: WCAG v2.0</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 86</a>: WCAG level AAA</p>                            
+						</td>
+					</tr>                    
+	                <tr>
+						<td>
+                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                <code>EPUB Accessibility 1.1 - WCAG 2.1 Level A</code></p>
+						</td>
+						<td>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 81</a>: WCAG v2.1</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 84</a>: WCAG level A</p>                            
+						</td>
+					</tr>  
+	                <tr>
+						<td>
+                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                <code>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</code></p>
+						</td>
+						<td>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 81</a>: WCAG v2.1</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 85</a>: WCAG level AA</p>                            
+						</td>
+					</tr>                    
+	                <tr>
+						<td>
+                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                <code>EPUB Accessibility 1.1 - WCAG 2.1 Level AAA</code></p>
+						</td>
+						<td>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 81</a>: WCAG v2.1</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 86</a>: WCAG level AAA</p>                            
+						</td>
+					</tr> 
+	                <tr>
+						<td>
+                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                <code>EPUB Accessibility 1.1 - WCAG 2.2 Level A</code></p>
+						</td>
+						<td>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 82</a>: WCAG v2.2</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 84</a>: WCAG level A</p>                            
+						</td>
+					</tr>  
+	                <tr>
+						<td>
+                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                <code>EPUB Accessibility 1.1 - WCAG 2.2 Level AA</code></p>
+						</td>
+						<td>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 82</a>: WCAG v2.2</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 85</a>: WCAG level AA</p>                            
+						</td>
+					</tr>                    
+	                <tr>
+						<td>
+                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                <code>EPUB Accessibility 1.1 - WCAG 2.1 Level AAA</code></p>
+						</td>
+						<td>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 82</a>: WCAG v2.2</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 86</a>: WCAG level AAA</p>                            
+						</td>
+					</tr> 
 				</tbody>
 			</table>
 		</section>

--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -145,28 +145,6 @@
 								by</p>
 						</td>
 					</tr>
-					<tr>
-						<td>
-							<p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-										><code>dcterms:conformsTo</code></a> with the URL
-                                <code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</code></p>
-						</td>
-						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 02</a>: EPUB Accessibility
-								Specification 1.0 A</p>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-										><code>dcterms:conformsTo</code></a> with the URL
-                                <code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa</code></p>
-						</td>
-						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 03</a>: EPUB Accessibility
-								Specification 1.0 AA</p>
-						</td>
-					</tr>
 	                <tr>
 						<td>
                             <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
@@ -274,7 +252,29 @@
 							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 82</a>: WCAG v2.2</p>
                             <p><a href="https://ns.editeur.org/onix/en/196/93">Code 86</a>: WCAG level AAA</p>                            
 						</td>
-					</tr> 
+					</tr>
+					<tr>
+						<td>
+							<p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the URL
+                                <code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</code></p>
+						</td>
+						<td>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 02</a>: EPUB Accessibility
+								Specification 1.0 A</p>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the URL
+                                <code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa</code></p>
+						</td>
+						<td>
+							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 03</a>: EPUB Accessibility
+								Specification 1.0 AA</p>
+						</td>
+					</tr>
 				</tbody>
 			</table>
 		</section>

--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -147,9 +147,9 @@
 					</tr>
 					<tr>
 						<td>
-                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-										><code>dcterms:conformsTo</code></a> with the text string<br/>
-                                <code>EPUB Accessibility 1.0 - WCAG 2.0 Level A</code></p>
+							<p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the URL
+                                <code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</code></p>
 						</td>
 						<td>
 							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 02</a>: EPUB Accessibility
@@ -158,9 +158,9 @@
 					</tr>
 					<tr>
 						<td>
-                            <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-                                  ><code>dcterms:conformsTo</code></a> with the text string<br/>
-                                <code>EPUB Accessibility 1.0 - WCAG 2.0 Level AA</code></p>
+							<p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
+										><code>dcterms:conformsTo</code></a> with the URL
+                                <code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa</code></p>
 						</td>
 						<td>
 							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 03</a>: EPUB Accessibility


### PR DESCRIPTION
Decided to remove the old 1.0 IDPF URLs since we probably don't want to promote that even for EPUB 3.2 as this new method with text strings is backward compatible.

Also added all WCAG 2.0, 2.1, and 2.2 A/AA/AA variations as each have their own ONIX set of codes.