### PR TITLE
Onix code list additions

### DIFF
--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -746,21 +746,35 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#auditory"
 										><code>auditory</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/63">List 63</a>: Product content type, 
+                            <ul>
+                            <li><a
+									href="https://ns.editeur.org/onix/en/63/01">Code 01</a>: Audiobook</li>
+                            <p>plus types of audio content</p>
+                            <li><a href="https://ns.editeur.org/onix/en/63/22">Code 22</a>: Additional audio content not part of main content</li>
+                            <li><a href="https://ns.editeur.org/onix/en/63/13">Code 13</a>: Other speech content</li>
+                            <li><a href="https://ns.editeur.org/onix/en/63/03">Code 03</a>: Music recording</li>
+                            <li><a href="https://ns.editeur.org/onix/en/63/04">Code 04</a>: Other audio</li>
+                            <li><a href="https://ns.editeur.org/onix/en/63/21">Code 21</a>: Partial performance – spoken word</li>
+                            <li><a href="https://ns.editeur.org/onix/en/63/23">Code 23</a>: Promotional audio for other book product</li>
+                            
+                            </ul>
+                        </td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#chartOnVisual"
 										><code>chartOnVisual</code></a></p></td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/81">List 81</a>: Product content type, <a
-									href="https://ns.editeur.org/onix/en/81/19">Code 19</a>: Figures, Diagrams,
+							<p><a href="https://ns.editeur.org/onix/en/63">List 81</a>: Product content type, <a
+									href="https://ns.editeur.org/onix/en/63/19">Code 19</a>: Figures, Diagrams,
 								Charts</p>
 						</td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#chemOnVisual"
 										><code>chemOnVisual</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/63">List 63</a>: Product content type, <a
+									href="https://ns.editeur.org/onix/en/63/47">Code 47</a>: Chemical content</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#colorDependent"
@@ -779,12 +793,14 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#mathOnVisual"
 										><code>mathOnVisual</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/63">List 63</a>: Product content type, <a
+									href="https://ns.editeur.org/onix/en/63/48">Code 48</a>: Mathematical content</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#musicOnVisual"
 										><code>musicOnVisual</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/63">List 63</a>: Product content type, <a
+									href="https://ns.editeur.org/onix/en/63/11">Code 11</a>: Musical notation</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#tactile"
@@ -794,7 +810,8 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#textOnVisual"
 										><code>textOnVisual</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/63">List 63</a>: Product content type, <a
+									href="https://ns.editeur.org/onix/en/63/49">Code 49</a>: Images of text</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#textual"
@@ -815,8 +832,13 @@
 								<li><a href="https://ns.editeur.org/onix/en/81/18">Code 18</a>: Photographs, or </li>
 								<li><a href="https://ns.editeur.org/onix/en/81/19">Code 19</a>: Figures, diagrams,
 									charts, graphs, or </li>
+                                <li><a href="https://ns.editeur.org/onix/en/81/20">Code 20</a>: Additional images / graphics not part of main work, or </li>
 								<li><a href="https://ns.editeur.org/onix/en/81/12">Code 12</a>: Maps and/or other
-									cartographic content</li>
+									cartographic content, or</li>
+                                <li><a href="https://ns.editeur.org/onix/en/81/46">Code 46</a>: Decorative images or graphics, or</li>
+                                <li><a href="https://ns.editeur.org/onix/en/81/42">Code 42</a>: Assessment material, or</li>
+                                <li><a href="https://ns.editeur.org/onix/en/81/50">Code 50</a>: Video content without audio, or</li>
+                                <li><a href="https://ns.editeur.org/onix/en/81/24">Code 24</a>: Animated / interactive illustrations</li>
 							</ul>
 						</td>
 					</tr>

--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -107,7 +107,7 @@
 
 			<div class="note">
 				<p>Unless stated otherwise, all code values are from ONIX <a href="https://ns.editeur.org/onix/en/196"
-						>code list 196</a>.</p>
+						>code list 196</a>: E-publication Accessibility Details.</p>
 			</div>
 
 			<table class="zebra">
@@ -286,7 +286,7 @@
 
 			<div class="note">
 				<p>Unless stated otherwise, all code values are from ONIX <a href="https://ns.editeur.org/onix/en/196"
-						>code list 196</a>.</p>
+						>code list 196</a>E-publication Accessibility Details.</p>
 			</div>
 
 			<table class="zebra">
@@ -312,9 +312,15 @@
 						<td><p>–</p></td>
 					</tr>
 					<tr>
+						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#alternativeText"
+										><code>ARIA</code></a></p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/196/30">Code 30</a>: ARIA roles provided</p></td>
+					</tr>
+                    
+					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#audioDescription"
 										><code>audioDescription</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/196/28">Code 28</a>: Full alternative audio descriptions</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#bookmarks"
@@ -324,7 +330,12 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#braille"
 									><code>braille</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/21">List 21</a>: Edition type, <a
+									href="https://ns.editeur.org/onix/en/21/BRL">Code BRL</a>: Braille edition</p>
+                            <p>or</p>
+                            <p><a href="https://ns.editeur.org/onix/en/175">List 175</a>: Product form detail, <a
+									href="https://ns.editeur.org/onix/en/175/E146">Code E146</a>: BRF(Braille-ready file) Electronic Braille file</p>
+                        </td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#captions"
@@ -341,12 +352,16 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#describedMath"
 										><code>describedMath</code></a></p></td>
-						<td><p>–</p></td>
+						<td>
+                            <p><a href="https://ns.editeur.org/onix/en/196/14">Code 14</a>: Short alternative textual descriptions</p>
+                            <p>along with</p>
+                            <p><a href="https://ns.editeur.org/onix/en/81">List 81</a>: Product content type, <a
+									href="https://ns.editeur.org/onix/en/81/48">Code 48</a>: Mathematical content</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#displayTransformability"
 										><code>displayTransformability</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/196/36">Code 36</a>: All textual content can be modified</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#fullRubyAnnotations"
@@ -356,12 +371,14 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#highContrastAudio"
 										><code>highContrastAudio</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/196/27">Code 27</a>: Use of high contrast between foreground and background audio</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#highContrastDisplay"
 										><code>highContrastDisplay</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/196/26">Code 26</a>: Use of high contrast between text and background color</p>
+                        <p>and</p>
+                        <p><a href="https://ns.editeur.org/onix/en/196/37">Code 37</a>: Use of ultra-high contrast between text foreground and background</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#horizontalWriting"
@@ -378,12 +395,20 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#largePrint"
 										><code>largePrint</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/21">List 21</a>: Edition type, <a
+									href="https://ns.editeur.org/onix/en/21/LTE">Code LTE</a>: Large type / large print edition</p>
+                            <p>and</p>
+                            <p><a href="https://ns.editeur.org/onix/en/21">List 21</a>: Edition type, <a
+									href="https://ns.editeur.org/onix/en/21/ULP">Code ULP</a>: Ultra large print edition</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#latex"
 								><code>latex</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/196/35">Code 35</a>: Accessible math content (as LaTeX)</p>
+                        <p>should be used with</p>
+                        <p><a href="https://ns.editeur.org/onix/en/81">List 81</a>: Product content type, <a
+									href="https://ns.editeur.org/onix/en/81/48">Code 48</a>: Mathematical content</p>
+                        </td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#longDescription"
@@ -405,7 +430,7 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#feature-none"
 										><code>none</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/196/09">Code 09</a>: Inaccessible, or known limited accessibility</p></td>
 					</tr>
 					<tr>
 						<td>
@@ -443,7 +468,7 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#structuralNavigation"
 										><code>structuralNavigation</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/196/29">Code 29</a>: Next / Previous structural navigation</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#sychronizedAudioText"
@@ -464,7 +489,7 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#taggedPDF"
 										><code>taggedPDF</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/196/05">Code 05</a>: PDF/UA</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#tactileGraphic"
@@ -499,12 +524,13 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#feature-unknown"
 										><code>unknown</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/196/08">Code 08</a>: Unknown accessibility</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#unlocked"
 										><code>unlocked</code></a></p></td>
-						<td><p>–</p></td>
+                        <td><p><a href="https://ns.editeur.org/onix/en/144">List 144:</a> E-publication technical protection, <a
+									href="https://ns.editeur.org/onix/en/144/00">Code 00</a>: 	None</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#verticalWriting"
@@ -720,7 +746,7 @@
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#chartOnVisual"
 										><code>chartOnVisual</code></a></p></td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/81">List 81</a>, <a
+							<p><a href="https://ns.editeur.org/onix/en/81">List 81</a>: Product content type, <a
 									href="https://ns.editeur.org/onix/en/81/19">Code 19</a>: Figures, Diagrams,
 								Charts</p>
 						</td>
@@ -739,7 +765,7 @@
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#diagramOnVisual"
 										><code>diagramOnVisual</code></a></p></td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/81">List 81</a>, <a
+							<p><a href="https://ns.editeur.org/onix/en/81">List 81</a>: Product content type, <a
 									href="https://ns.editeur.org/onix/en/81/19">Code 19</a>: Figures, Diagrams,
 								Charts</p>
 						</td>
@@ -768,20 +794,15 @@
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#textual"
 									><code>textual</code></a></p></td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/81">List 81</a>, <a
-									href="https://ns.editeur.org/onix/en/81/10">Code 10</a>: "Text (eye-readable)"
-								combined with <a href="https://ns.editeur.org/onix/en/196">List 196</a>, <a
-									href="https://ns.editeur.org/onix/en/196/10">Code 10</a>: "No reading system
-								accessibility options disabled (except)" means all text is actual text.</p>
-							<p>Note that List 81, Code 10 on its own (without List 196, Code 10) admits the possibility
-								that the "text" is inaccessible because it is an image of text.</p>
+							<p><a href="https://ns.editeur.org/onix/en/196">List 196</a>: E-publication Accessibility Details, <a
+									href="https://ns.editeur.org/onix/en/196/52">Code 52</a>: All non-decorative content supports reading without sight</p>
 						</td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#visual"
 									><code>visual</code></a></p></td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/81">List 81</a></p>
+							<p><a href="https://ns.editeur.org/onix/en/81">List 81</a>: Product content type,</p>
 							<ul>
 								<li><a href="https://ns.editeur.org/onix/en/81/07">Code 07</a>: Still images / graphics,
 									or</li>
@@ -807,7 +828,7 @@
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#ams-auditory"
 										><code>auditory</code></a></p></td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/81">List 81</a>, <a
+							<p><a href="https://ns.editeur.org/onix/en/81">List 81</a>: Product content type, <a
 									href="https://ns.editeur.org/onix/en/81/01">Code 01</a>: Audiobook</p>
 						</td>
 					</tr>
@@ -819,13 +840,8 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#ams-textual"
 										><code>textual</code></a></p></td>
-						<td><p><a href="https://ns.editeur.org/onix/en/81">List 81</a>, <a
-									href="https://ns.editeur.org/onix/en/81/10">Code 10</a>: "Text (eye-readable)"
-								combined with <a href="https://ns.editeur.org/onix/en/196">List 196</a>, <a
-									href="https://ns.editeur.org/onix/en/196/10">Code 10</a>: "No reading system
-								accessibility options disabled (except)" means all text is actual text.</p>
-							<p>Note that List 81, Code 10 on its own (without List 196, Code 10) admits the possibility
-								that the "text" is inaccessible because it is an image of text.</p></td>
+						<td>							<p><a href="https://ns.editeur.org/onix/en/196">List 196</a>: E-publication Accessibility Details, <a
+									href="https://ns.editeur.org/onix/en/196/52">Code 52</a>: All non-decorative content supports reading without sight</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#ams-visual"

--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -582,42 +582,48 @@
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#flashing"
 										><code>flashing</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/143">List 143</a>: US CPSIA or other international hazard warning type, <a
+									href="https://ns.editeur.org/onix/en/143/13">Code 13</a>: WARNING – Flashing hazard</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#motionSimulation"
 										><code>motionSimulation</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/143">List 143</a>: US CPSIA or other international hazard warning type, <a
+									href="https://ns.editeur.org/onix/en/143/17">Code 17</a>: WARNING – Motion simulation hazard</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#sound"
 								><code>sound</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/143">List 143</a>: US CPSIA or other international hazard warning type, <a
+									href="https://ns.editeur.org/onix/en/143/15">Code 15</a>: WARNING – Sound hazard</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#hazard-none"
 									><code>none</code></a></p></td>
-						<td><p>–</p></td>
+				<td><p>–</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#noFlashingHazard"
 										><code>noFlashingHazard</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/143">List 143</a>: US CPSIA or other international hazard warning type, <a
+									href="https://ns.editeur.org/onix/en/143/14">Code 14</a>: No flashing hazard warning necessary</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#noMotionSimulationHazard"
 										><code>noMotionSimulationHazard</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/143">List 143</a>: US CPSIA or other international hazard warning type, <a
+									href="https://ns.editeur.org/onix/en/143/18">Code 18</a>: No motion simulation hazard warning necessary</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#noSoundHazard"
 										><code>noSoundHazard</code></a></p></td>
-						<td><p>–</p></td>
+						<td><p><a href="https://ns.editeur.org/onix/en/143">List 143</a>: US CPSIA or other international hazard warning type, <a
+									href="https://ns.editeur.org/onix/en/143/16">Code 16</a>: No sound hazard warning necessary/p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#hazard-unknown"
 										><code>unknown</code></a></p></td>
-						<td><p>–</p></td>
+                        <td><p>–</p></td>
 					</tr>
 					<tr>
 						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#unknownFlashingHazard"

--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -153,9 +153,9 @@
                                 <code>EPUB Accessibility 1.1 - WCAG 2.0 Level A</code></p>
 						</td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 80</a>: WCAG v2.0</p>
-                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 84</a>: WCAG level A</p>                            
+							<p><a href="https://ns.editeur.org/onix/en/196/04">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/80">Code 80</a>: WCAG v2.0</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/84">Code 84</a>: WCAG level A</p>                            
 						</td>
 					</tr>  
 	                <tr>
@@ -165,9 +165,9 @@
                                 <code>EPUB Accessibility 1.1 - WCAG 2.0 Level AA</code></p>
 						</td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 80</a>: WCAG v2.0</p>
-                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 85</a>: WCAG level AA</p>                            
+							<p><a href="https://ns.editeur.org/onix/en/196/04">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/80">Code 80</a>: WCAG v2.0</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/85">Code 85</a>: WCAG level AA</p>                            
 						</td>
 					</tr>                    
 	                <tr>
@@ -177,9 +177,9 @@
                                 <code>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</code></p>
 						</td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 80</a>: WCAG v2.0</p>
-                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 86</a>: WCAG level AAA</p>                            
+							<p><a href="https://ns.editeur.org/onix/en/196/04">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/80">Code 80</a>: WCAG v2.0</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/86">Code 86</a>: WCAG level AAA</p>                            
 						</td>
 					</tr>                    
 	                <tr>
@@ -189,9 +189,9 @@
                                 <code>EPUB Accessibility 1.1 - WCAG 2.1 Level A</code></p>
 						</td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 81</a>: WCAG v2.1</p>
-                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 84</a>: WCAG level A</p>                            
+							<p><a href="https://ns.editeur.org/onix/en/196/04">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/81">Code 81</a>: WCAG v2.1</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/84">Code 84</a>: WCAG level A</p>                            
 						</td>
 					</tr>  
 	                <tr>
@@ -201,9 +201,9 @@
                                 <code>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</code></p>
 						</td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 81</a>: WCAG v2.1</p>
-                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 85</a>: WCAG level AA</p>                            
+							<p><a href="https://ns.editeur.org/onix/en/196/04">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/81">Code 81</a>: WCAG v2.1</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/85">Code 85</a>: WCAG level AA</p>                            
 						</td>
 					</tr>                    
 	                <tr>
@@ -213,9 +213,9 @@
                                 <code>EPUB Accessibility 1.1 - WCAG 2.1 Level AAA</code></p>
 						</td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 81</a>: WCAG v2.1</p>
-                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 86</a>: WCAG level AAA</p>                            
+							<p><a href="https://ns.editeur.org/onix/en/196/04">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/81">Code 81</a>: WCAG v2.1</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/86">Code 86</a>: WCAG level AAA</p>                            
 						</td>
 					</tr> 
 	                <tr>
@@ -225,9 +225,9 @@
                                 <code>EPUB Accessibility 1.1 - WCAG 2.2 Level A</code></p>
 						</td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 82</a>: WCAG v2.2</p>
-                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 84</a>: WCAG level A</p>                            
+							<p><a href="https://ns.editeur.org/onix/en/196/04">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/82">Code 82</a>: WCAG v2.2</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/84">Code 84</a>: WCAG level A</p>                            
 						</td>
 					</tr>  
 	                <tr>
@@ -237,9 +237,9 @@
                                 <code>EPUB Accessibility 1.1 - WCAG 2.2 Level AA</code></p>
 						</td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 82</a>: WCAG v2.2</p>
-                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 85</a>: WCAG level AA</p>                            
+							<p><a href="https://ns.editeur.org/onix/en/196/04">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/82">Code 82</a>: WCAG v2.2</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/85">Code 85</a>: WCAG level AA</p>                            
 						</td>
 					</tr>                    
 	                <tr>
@@ -249,9 +249,9 @@
                                 <code>EPUB Accessibility 1.1 - WCAG 2.1 Level AAA</code></p>
 						</td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 04</a>: EPUB Accessibility Specification 1.1</p>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 82</a>: WCAG v2.2</p>
-                            <p><a href="https://ns.editeur.org/onix/en/196/93">Code 86</a>: WCAG level AAA</p>                            
+							<p><a href="https://ns.editeur.org/onix/en/196/04">Code 04</a>: EPUB Accessibility Specification 1.1</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/82">Code 82</a>: WCAG v2.2</p>
+                            <p><a href="https://ns.editeur.org/onix/en/196/86">Code 86</a>: WCAG level AAA</p>                            
 						</td>
 					</tr>
 					<tr>
@@ -261,7 +261,7 @@
                                 <code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</code></p>
 						</td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 02</a>: EPUB Accessibility
+							<p><a href="https://ns.editeur.org/onix/en/196/02">Code 02</a>: EPUB Accessibility
 								Specification 1.0 A</p>
 						</td>
 					</tr>
@@ -272,7 +272,7 @@
                                 <code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa</code></p>
 						</td>
 						<td>
-							<p><a href="https://ns.editeur.org/onix/en/196/93">Code 03</a>: EPUB Accessibility
+							<p><a href="https://ns.editeur.org/onix/en/196/03">Code 03</a>: EPUB Accessibility
 								Specification 1.0 AA</p>
 						</td>
 					</tr>


### PR DESCRIPTION
The suggested improvements made by @chrisONIX in [this previous pull request](https://github.com/w3c/a11y-discov-vocab/pull/96)
Also addressed items outlined in #95 

Added the following, and fixed a number of link issues introduced in previous pull request regarding conformance links into ONIX code pages.


Here are some suggested proposals for crosswalk to ONIX - based on missing ONIX values in current version

latest version of code lists for ONIX are available here. [https://ns.editeur.org/onix/en]
Accessibility features
audioDescription - List 196 - code 28
braille - List 21 - code BRL (Braille edition) - there are other options as well. List 175 - code BRF - format is digital braille
describedMath - List 196 - code 14 (Should be used with List 81 - code 48 - Mathematical content)
displayTransformability - List 196 - code 36
highContrastAudio - List 196 - code 27
highContrastDisplay - List 196 - codes 26 & 37
largePrint - code list 21 - codes LTE and ULP
latex - code list 196 - code 35 (Should be used with List 81 - code 48 - Mathematical content)
none - code list 196 - code 09
page navigation - code list 196 - code 19
structuralNavigation - code list 196 - code 29
taggedPDF - code list 196 - code 05
unknown - code list 196 - code 08
unlocked - code list 144 - code 00
Hazards
flashing - code list 143 - code 13
noFlashingHazard -code list 143 - code 14
motionSimulation - code list 143 - code 17
noMotionSimulationHazard - code list 143 - code 18
sound - code list 143 - code 15
noSoundHazard - code list 143 - code 16
unknown - code list 196 - code 08

Access Mode
Access mode is dealt with in list 81 - which covers all digital products and their features for all the market.
We encourage users to also use values from 196 - confirming accessibility.

auditory - code list 81 - main code 01 (plus 22, 13, 03, 04, 21, 22, 23) - covers the variety of audio content
chemOnVisual - code list 81 - code 47
colorDependent (ONIX does the other way around - see code list 196 _ code 25
mathOnVisual -code list 81 - code 48
musicOnVisual - code list 81 - code 11
textOnVisual - code list 81 - code 49
textual - code list 81 - main code 10 (plus codes 16, 45)
visual - code list 81 - codes 07, 18, 19, 20, 12, 46, 42, 50, 24

Access Mode Sufficient

textual - code list 196 - code 52.