### PR TITLE
Adds Accessibility Addendum as an option for Accessibility Summary

### DIFF
--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -833,6 +833,7 @@
 										><code>accessibilitySummary</code></a></p></td>
 						<td>
 							<p><a href="https://ns.editeur.org/onix/en/196/00">Code 00</a>: Accessibility summary</p>
+							<p><a href="https://ns.editeur.org/onix/en/196/92">Code 92</a>: Accessibility addendum</p>
 						</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
[Accessibility Summary Authoring Guidelines (Draft Community Group Report 25 April 2024)](https://w3c.github.io/publ-a11y/drafts/schema-a11y-summary/#title) proposes a strong change in the use of the Accessibility Summary metadata. This change of approach is interpreted in ONIX as a new metadata field. This commit only adds the "Accessibility Addendum" metadata as a possible correspondence for "Accessibility Summary". Adding a note and context could be a good option to consider.