### PR TITLE
Adding risk types unknown (ONIX List 143)

### DIFF
--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -653,20 +653,18 @@
                         <td><p>–</p></td>
 					</tr>
 					<tr>
-						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#unknownFlashingHazard"
-										><code>unknownFlashingHazard</code></a></p></td>
-						<td><p>–</p></td>
-					</tr>
-					<tr>
-						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#unknownMotionSimulationHazard"
-										><code>unknownMotionSimulationHazard</code></a></p></td>
-						<td><p>–</p></td>
-					</tr>
-					<tr>
-						<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#unknownSoundHazard"
-										><code>unknownSoundHazard</code></a></p></td>
-						<td><p>–</p></td>
-					</tr>
+						<tr>
+							<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#unknownFlashingHazard"><code>unknownFlashingHazard</code></a></p></td>
+							<td><p><a href="https://ns.editeur.org/onix/en/143/24">List: 143; Code: 24</a> Flashing risk unknown</p></td>
+						</tr>
+						<tr>
+							<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#unknownMotionSimulationHazard"><code>unknownMotionSimulationHazard</code></a></p></td>
+							<td><p><a href="https://ns.editeur.org/onix/en/143/26">List: 143; Code: 26</a> Motion simulation unknown</p></td>
+						</tr>
+						<tr>
+							<td><p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#unknownSoundHazard"><code>unknownSoundHazard</code></a></p></td>
+							<td><p><a href="https://ns.editeur.org/onix/en/143/25">List: 143; Code: 25</a> sound risk unknown</p></td>
+						</tr>
 				</tbody>
 
 				<tbody>


### PR DESCRIPTION
Following discussion at [pcg-a11y #323](https://github.com/w3c/publ-a11y/issues/323)

(this three codes were added in july 2024)