### PR TITLE
Add visual content indicators section

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 				group: "a11y-discov-vocab",
 				specStatus: "CG-DRAFT",
 				noRecTrack: true,
-				previousPublishDate: '2024-07-18',
+				previousPublishDate: '2024-09-06',
 				previousMaturity: 'CG-FINAL',
 				shortName: 'vocabulary',
 				edDraftURI: "https://w3c.github.io/a11y-discov-vocab/",
@@ -113,7 +113,7 @@
 			</section>
 
 			<section id="naming">
-				<h3>Vocabulary Naming Convention</h3>
+				<h3>Vocabulary naming convention</h3>
 
 				<p>The values defined in this vocabulary follow a camel casing convention: single words are lowercase,
 					while compound words are concatenated into a single value with a capital letter indicating the start
@@ -142,7 +142,7 @@
 			</section>
 
 			<section id="extensions">
-				<h3>Extending the Vocabulary</h3>
+				<h3>Extending the vocabulary</h3>
 
 				<p>To extend terms with more information, this vocabulary used to recommend the old <a
 						href="https://schema.org/docs/old_extension.html">slash extension syntax</a> employed by
@@ -170,7 +170,7 @@
 			</section>
 		</section>
 		<section id="accessibilityAPI">
-			<h2>The <code>accessibilityAPI</code> Property</h2>
+			<h2>The <code>accessibilityAPI</code> property</h2>
 
 			<section id="accessibilityAPI-application">
 				<h3>Application</h3>
@@ -379,7 +379,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 			</section>
 		</section>
 		<section id="accessibilityControl">
-			<h2>The <code>accessibilityControl</code> Property</h2>
+			<h2>The <code>accessibilityControl</code> property</h2>
 
 			<section id="accessibilityControl-application">
 				<h3>Application</h3>
@@ -513,7 +513,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 			</section>
 		</section>
 		<section id="accessibilityFeature">
-			<h2>The <code>accessibilityFeature</code> Property</h2>
+			<h2>The <code>accessibilityFeature</code> property</h2>
 
 			<section id="accessibilityFeature-application">
 				<h3>Application</h3>
@@ -685,7 +685,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				<h3>Vocabulary</h3>
 
 				<section id="structure-and-navigation-terms">
-					<h4>Structure and Navigation Terms</h4>
+					<h4>Structure and navigation terms</h4>
 
 					<p>The structure and navigation term identify structuring and navigation aids that facilitate use of
 						a resource.</p>
@@ -796,7 +796,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				</section>
 
 				<section id="adaptation-terms">
-					<h4>Adaptation Terms</h4>
+					<h4>Adaptation terms</h4>
 
 					<p>The adaptation terms identify provisions in the content that enable reading in alternative access
 						modes.</p>
@@ -891,7 +891,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				</section>
 
 				<section id="rendering-control-terms">
-					<h4>Rendering Control Terms</h4>
+					<h4>Rendering control terms</h4>
 
 					<p>The rendering control values identify that access to a resource and rendering and playback of its
 						content can be controlled for easier reading.</p>
@@ -964,7 +964,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				</section>
 
 				<section id="specialized-markup-terms">
-					<h4>Specialized Markup Terms</h4>
+					<h4>Specialized markup terms</h4>
 
 					<p>The specialized markup terms identify content available in specialized markup grammars. These
 						grammars typically provide users with enhanced structure and navigation capabilities.</p>
@@ -1011,7 +1011,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				</section>
 
 				<section id="clarity-terms">
-					<h4>Clarity Terms</h4>
+					<h4>Clarity terms</h4>
 
 					<p>The clarity terms identify ways that the content has been enhanced for improved auditory or
 						visual clarity.</p>
@@ -1055,7 +1055,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				</section>
 
 				<section id="tactile-terms">
-					<h4>Tactile Terms</h4>
+					<h4>Tactile terms</h4>
 
 					<p>The tactile terms identify content that is available in tactile form.</p>
 
@@ -1100,11 +1100,10 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				</section>
 
 				<section id="internationalization-terms">
-					<h4>Internationalization Terms</h4>
+					<h4>Internationalization terms</h4>
 
 					<p>The internationalization terms identify those accessibility characteristics of the content which
 						are required for internationalization.</p>
-
 
 					<section id="fullRubyAnnotations">
 						<h5>fullRubyAnnotations</h5>
@@ -1167,6 +1166,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 						<p>Indicates that the content can be rendered without additional word segmentation.</p>
 					</section>
 				</section>
+
 				<section id="feature-none">
 					<h5>none</h5>
 
@@ -1186,7 +1186,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 			</section>
 		</section>
 		<section id="accessibilityHazard">
-			<h2>The <code>accessibilityHazard</code> Property</h2>
+			<h2>The <code>accessibilityHazard</code> property</h2>
 
 			<section id="accessibilityHazard-application">
 				<h3>Application</h3>
@@ -1424,9 +1424,9 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					<section id="flashing">
 						<h5>flashing</h5>
 
-					<p>This value should be set when the content meets the hazard thresholds described in <a
-							href="https://www.w3.org/TR/WCAG2/#three-flashes-or-below-threshold">Success Criterion 2.3.1
-							Three Flashes or Below Threshold</a> [[WCAG2]].</p>
+						<p>This value should be set when the content meets the hazard thresholds described in <a
+								href="https://www.w3.org/TR/WCAG2/#three-flashes-or-below-threshold">Success Criterion
+								2.3.1 Three Flashes or Below Threshold</a> [[WCAG2]].</p>
 
 						<p>Indicates that the resource presents a flashing hazard for photosensitive persons.</p>
 
@@ -1592,7 +1592,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 			</section>
 		</section>
 		<section id="accessibilitySummary">
-			<h2>The <code>accessibilitySummary</code> Property</h2>
+			<h2>The <code>accessibilitySummary</code> property</h2>
 
 			<blockquote>
 				<p>A human-readable summary of specific accessibility features or deficiencies, consistent with the
@@ -1666,7 +1666,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 			</aside>
 		</section>
 		<section id="accessMode">
-			<h2>The <code>accessMode</code> Property</h2>
+			<h2>The <code>accessMode</code> property</h2>
 
 			<section id="accessMode-application">
 				<h3>Application</h3>
@@ -1771,6 +1771,59 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					</div>
 				</section>
 
+				<section id="tactile">
+					<h4>tactile</h4>
+
+					<p>Indicates that the resource contains information encoded in tactile form.</p>
+
+					<p>Note that although an indication of a tactile mode often indicates the content is encoded using a
+						braille system, this is not always the case. Tactile perception may also indicate, for example,
+						the use of tactile graphics to convey information.</p>
+				</section>
+
+				<section id="textual">
+					<h4>textual</h4>
+
+					<p>Indicates that the resource contains information encoded in textual form.</p>
+
+					<div class="note">
+						<p>This value is not set if the only textual content is for navigational purposes. For example,
+							an audiobook might include a table of contents, but it is not necessary to read the table of
+							contents to read the work. Likewise, books with synchronized text-audio playback may only
+							include headings to allow structured navigation.</p>
+					</div>
+				</section>
+
+				<section id="visual">
+					<h4>visual</h4>
+
+					<p>Indicates that the resource contains information encoded in visual form.</p>
+
+					<div class="note">
+						<p>This value is not set if the only visual imagery is presentational or not directly relevant
+							to understanding the content. Examples of this type of imagery include cover images for
+							publications, corporate logos, and purely decorative images.</p>
+					</div>
+				</section>
+			</section>
+
+			<section id="accessMode-visuals">
+				<h3>Visual content indicators</h3>
+
+				<div class="advisement">
+					<p>Caution: Although user agents should infer a <a href="#visual">visual access mode</a> when any of
+						the values defined in this section is set, it is strongly recommended not to rely on this
+						behaviour. Always set the value <code>visual</code> in addition to these indicators.</p>
+				</div>
+
+				<p>The visual content indicators are not strictly access modes but combine a visual access mode with
+					information about the nature of the visual content in a publication, such as whether charts, music,
+					or math equations are encoded as images.</p>
+
+				<p>Users can then decide whether the content will still meet their needs. For example, if the math
+					equations in a textbook are encoded as images, with only text descriptions to make them accessible,
+					a user might opt to keep searching for an alternative that uses MathML markup.</p>
+
 				<section id="chartOnVisual">
 					<h4>chartOnVisual</h4>
 
@@ -1808,45 +1861,10 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					<p>Indicates that the resource contains musical notation encoded in visual form.</p>
 				</section>
 
-				<section id="tactile">
-					<h4>tactile</h4>
-
-					<p>Indicates that the resource contains information encoded in tactile form.</p>
-
-					<p>Note that although an indication of a tactile mode often indicates the content is encoded using a
-						braille system, this is not always the case. Tactile perception may also indicate, for example,
-						the use of tactile graphics to convey information.</p>
-				</section>
-
 				<section id="textOnVisual">
 					<h4>textOnVisual</h4>
 
 					<p>Indicates that the resource contains text encoded in visual form.</p>
-				</section>
-
-				<section id="textual">
-					<h4>textual</h4>
-
-					<p>Indicates that the resource contains information encoded in textual form.</p>
-
-					<div class="note">
-						<p>This value is not set if the only textual content is for navigational purposes. For example,
-							an audiobook might include a table of contents, but it is not necessary to read the table of
-							contents to read the work. Likewise, books with synchronized text-audio playback may only
-							include headings to allow structured navigation.</p>
-					</div>
-				</section>
-
-				<section id="visual">
-					<h4>visual</h4>
-
-					<p>Indicates that the resource contains information encoded in visual form.</p>
-
-					<div class="note">
-						<p>This value is not set if the only visual imagery is presentational or not directly relevant
-							to understanding the content. Examples of this type of imagery include cover images for
-							publications, corporate logos, and purely decorative images.</p>
-					</div>
 				</section>
 			</section>
 		</section>
@@ -2144,7 +2162,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 			</section>
 		</section>
 		<section id="change-log" class="appendix">
-			<h2>Change Log</h2>
+			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes to the vocabulary &#8212; those that add or
 				deprecate terms, or are similarly noteworthy.</p>
@@ -2158,7 +2176,20 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				  - only add open attribute to current year
 			-->
 
-			<details open="">
+			<details id="changes-2024" open="">
+				<summary>Changes made in 2024</summary>
+				<ul>
+					<li>25-Nov-2024: Moved the visual access modes that combine descriptions about the nature of the
+						visual content into a new section and caution that they should always be paired with the value
+							<code>visual</code>. Refer to <a href="https://github.com/w3c/epub-specs/issues/2653">issue
+							2653</a> in the EPUB tracker.</li>
+					<li>27-May-2024: Added a new section on appending descriptors to existing values using hyphens. Also
+						added two descriptors: <code>MathML-chemistry</code> and <code>latex-chemistry</code>. Refer to
+							<a href="https://github.com/w3c/a11y-discov-vocab/issues/106">issue 106</a>.</li>
+				</ul>
+			</details>
+
+			<details id="changes-2023">
 				<summary>Changes made in 2023</summary>
 				<ul>
 					<li>18-July-2023: Added internationalization values for ruby, writing direction, and word
@@ -2183,7 +2214,7 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 				</ul>
 			</details>
 
-			<details>
+			<details id="changes-2022">
 				<summary>Changes made in 2022</summary>
 				<ul>
 					<li>10-June-2022: Removed references to using the slash syntax to extend terms and recommend against


### PR DESCRIPTION
This is my best attempt to try and address the issue raised in https://github.com/w3c/epub-specs/issues/2653

I've taken all the access modes that are describing visual content and created a new section called "Visual content indicators" for them. I've tried to explain that these are expanding on access mode visual but also caution that "visual" should always be set with them.

That's the best I can think of to avoid removing or deprecating them, but other ideas welcome.

I've also standardized the casing of the section titles and added a change log for 2024 (with the missed entry for the descriptor mechanism we added over the summer).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 25, 2024, 2:37 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
Timed out after waiting 30000ms
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/a11y-discov-vocab%23118.)._
</details>
