### PR TITLE
ONIX: ttsMarkup and highContrast enhancements regarding issue #156

### DIFF
--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -631,10 +631,20 @@
 					<td>Content meets the visual contrast threshold set out in <a href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced">WCAG Success
 						Criteria 1.4.6</a>.</td>
 					<td><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#highContrastDisplay">highContrastDisplay</a></td>
-                    <td><p><a href="https://ns.editeur.org/onix/en/196/26">Code 26</a>: Use of high contrast between text and background color</p>
-                    <p>and</p>
+                    <td>
                     <p><a href="https://ns.editeur.org/onix/en/196/37">Code 37</a>: Use of ultra-high contrast between text foreground and background</p></td>
 					<td>3410#$atextual$b highContrastDisplay$2sapdv or 3410#$avisual$c highContrastDisplay$2sapd</td>
+					<td>-</td>
+					<td>-</td>
+					<td>-</td>
+				</tr>
+				<tr>
+					<td>Meets Contrast Minimum (text and images of text) <a href="https://www.w3.org/TR/WCAG22/#contrast-minimum">WCAG Success
+						Criteria 1.4.3</a>.</td>
+					<td>-</td>
+                    <td><p><a href="https://ns.editeur.org/onix/en/196/26">Code 26</a>: Use of high contrast between text and background color</p>
+                    </td>
+					<td>-</td>
 					<td>-</td>
 					<td>-</td>
 					<td>-</td>
@@ -967,14 +977,23 @@
 						used to enhance text-to-speech playback quality.</td>
 					<td><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#ttsMarkup">ttsMarkup</a></td>
 					<td><a href="https://ns.editeur.org/onix/en/196/21">List: 196; Code: 21</a>: Text-to-speech
-						hinting provided; <a href="https://ns.editeur.org/onix/en/196/22">Code 22</a>: Language tagging
-						provided</td>
+						hinting provided;</td>
 					<td>341$atext$bttsMarkup$2sapdv and 532 1# $a Text-to-speech has been optimised through provision of
 						PLS lexicons, SSML or CSS Speech synthesis hints.</td>
 					<td>-</td>
 					<td>-</td>
 					<td>231 $i21$2onix196 and/or 231 $i22$2onix196</td>
 				</tr>
+				<tr>
+					<td>Language Tagging</td>
+					<td>-</td>
+					<td><a href="https://ns.editeur.org/onix/en/196/22">Code 22</a>: Language tagging
+						provided</td>
+					<td>-</td>
+					<td>-</td>
+					<td>-</td>
+					<td>231 $i21$2onix196 and/or 231 $i22$2onix196</td>
+				</tr>                
                 <tr>
                     <td>
                         <p>Indicates that the author has not yet checked if the resource contains accessibility features. This value is only intended as a placeholder until an accessibility review can be completed.</p>


### PR DESCRIPTION
Split out ttsMarkup with Language Tagging, and highContrast AA vs. AAA requirements.
Please review the definitions of each new item to ensure this is what was meant as these were not discussed in the original ticket #156 