### PR TITLE
Remove xhtml namespace

### DIFF
--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-
+<html lang="en-US">
 <head>
-	<meta charset="utf-8" />
+	<meta charset="utf-8">
 	<title>Accessibility Properties Crosswalk (schema.org, ONIX, MARC21 &amp; UNIMARC)</title>
 	<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 	<script src="../common/js/permalink-a11y.js" class="remove"></script>
@@ -231,7 +230,7 @@
                     <td>An established standard to which the described resource conforms.</td>
                     <td>
                         <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-                                    ><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                    ><code>dcterms:conformsTo</code></a> with the text string<br>
                             <code>EPUB Accessibility 1.1 - WCAG 2.0 Level AA</code></p>
                     </td>
                     <td>
@@ -252,7 +251,7 @@
                     <td>An established standard to which the described resource conforms.</td>
                     <td>
                         <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-                                    ><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                    ><code>dcterms:conformsTo</code></a> with the text string<br>
                             <code>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</code></p>
                     </td>
                     <td>
@@ -274,7 +273,7 @@
                     <td>An established standard to which the described resource conforms.</td>
                     <td>
                         <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-                                    ><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                    ><code>dcterms:conformsTo</code></a> with the text string<br>
                             <code>EPUB Accessibility 1.1 - WCAG 2.1 Level A</code></p>
                     </td>
                     <td>
@@ -296,7 +295,7 @@
                     <td>An established standard to which the described resource conforms.</td>
                     <td>
                         <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-                                    ><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                    ><code>dcterms:conformsTo</code></a> with the text string<br>
                             <code>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</code></p>
                     </td>
                     <td>
@@ -317,7 +316,7 @@
                     <td>An established standard to which the described resource conforms.</td>
                     <td>
                         <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-                                    ><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                    ><code>dcterms:conformsTo</code></a> with the text string<br>
                             <code>EPUB Accessibility 1.1 - WCAG 2.1 Level AAA</code></p>
                     </td>
                     <td>
@@ -339,7 +338,7 @@
                     <td>An established standard to which the described resource conforms.</td>
                     <td>
                         <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-                                    ><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                    ><code>dcterms:conformsTo</code></a> with the text string<br>
                             <code>EPUB Accessibility 1.1 - WCAG 2.2 Level A</code></p>
                     </td>
                     <td>
@@ -360,7 +359,7 @@
                     <td>An established standard to which the described resource conforms.</td>
                     <td>
                         <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-                                    ><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                    ><code>dcterms:conformsTo</code></a> with the text string<br>
                             <code>EPUB Accessibility 1.1 - WCAG 2.2 Level AA</code></p>
                     </td>
                     <td>
@@ -382,7 +381,7 @@
                     <td>An established standard to which the described resource conforms.</td>
                     <td>
                         <p><a href="https://www.w3.org/TR/epub-a11y/#sec-conf-reporting-pub"
-                                    ><code>dcterms:conformsTo</code></a> with the text string<br/>
+                                    ><code>dcterms:conformsTo</code></a> with the text string<br>
                             <code>EPUB Accessibility 1.1 - WCAG 2.2 Level AAA</code></p>
                     </td>
                     <td>
@@ -456,7 +455,7 @@
                 <tr>
                     <td>Identifies the accessibility exemption the EPUB publication falls under.</td>
                     <td>
-                        <p><code><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a></code> with the text string<br/><code><a href="https://www.w3.org/TR/epub-a11y-exemption/#eaa-microenterprise">eaa-microenterprise</a></code></p>
+                        <p><code><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a></code> with the text string<br><code><a href="https://www.w3.org/TR/epub-a11y-exemption/#eaa-microenterprise">eaa-microenterprise</a></code></p>
                     </td>
                     <td>
                         <p><a href="https://ns.editeur.org/onix/en/196/75">List 196; Code 75</a>: EAA exception 1 - Micro-enterprises</p>
@@ -470,7 +469,7 @@
                 <tr>
                      <td>Identifies the accessibility exemption the EPUB publication falls under.</td>
                    <td>
-                        <p><code><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a></code> with the text string<br/><code><a href="https://www.w3.org/TR/epub-a11y-exemption/#eaa-disproportionate-burden">eaa-disproportionate-burden</a></code></p>
+                        <p><code><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a></code> with the text string<br><code><a href="https://www.w3.org/TR/epub-a11y-exemption/#eaa-disproportionate-burden">eaa-disproportionate-burden</a></code></p>
                     </td>
                     <td>
                         <p><a href="https://ns.editeur.org/onix/en/196/76">List 196; Code 76</a>: EAA exception 2 - Disproportionate burden</p>
@@ -484,7 +483,7 @@
                 <tr>
                     <td>Identifies the accessibility exemption the EPUB publication falls under.</td>
                     <td> 
-                        <p><code><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a></code> with the text string<br/><code><a href="https://www.w3.org/TR/epub-a11y-exemption/#eaa-fundamental-alteration">eaa-fundamental-alteration</a></code></p>
+                        <p><code><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a></code> with the text string<br><code><a href="https://www.w3.org/TR/epub-a11y-exemption/#eaa-fundamental-alteration">eaa-fundamental-alteration</a></code></p>
                     </td>
                     <td>
                         <p><a href="https://ns.editeur.org/onix/en/196/77">List 196; Code 77</a>: EAA exception 3 - Fundamental alteration</p>
@@ -946,7 +945,7 @@
                         <p>The resource includes static page markers, such as those identified by the doc-pagebreak role [[DPUB-ARIA-1.1]].</p>
                         <p>This value is most commonly used with ebooks for which there is a statically paginated equivalent, such as a print edition, but it is not required that the page markers correspond to another work. The markers may exist solely to facilitate navigation in purely digital works.</p></td>
                     <td>
-                        <p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#pageBreakMarkers"><code>pageBreakMarkers</code></a><br /> (formerly
+                        <p><a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#pageBreakMarkers"><code>pageBreakMarkers</code></a><br> (formerly
                             <code>printPageNumbers</code>)</p>
                     </td>
                     <td>

--- a/index.html
+++ b/index.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Schema.org Accessibility Properties for Discoverability Vocabulary</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="common/js/examples.js" class="remove"></script>
 		<script src="common/js/previousRelease.js" class="remove"></script>
 		<script src="common/js/css-inline.js" class="remove"></script>
 		<script class="remove">
-			//<![CDATA[
 			var respecConfig = {
 				group: "a11y-discov-vocab",
 				specStatus: "CG-DRAFT",
@@ -66,7 +65,6 @@
 				preProcess: [formatExamples,inlineCustomCSS],
 				postProcess: [addPreviousRelease,formatExampleTitles]
 			};
-			//]]>
 		</script>
 	</head>
 	<body>
@@ -1448,11 +1446,11 @@ Interoperability with platform APIs is an issue for Reading Systems</pre>
 					<section id="flashing">
 						<h5>flashing</h5>
 
+						<p>Indicates that the resource presents a flashing hazard for photosensitive persons.</p>
+						
 						<p>This value should be set when the content meets the hazard thresholds described in <a
 								href="https://www.w3.org/TR/WCAG2/#three-flashes-or-below-threshold">Success Criterion
 								2.3.1 Three Flashes or Below Threshold</a> [[WCAG2]].</p>
-
-						<p>Indicates that the resource presents a flashing hazard for photosensitive persons.</p>
 
 						<p>The <code>flashing</code> value must not be set when any of the <a href="#noFlashingHazard"
 									><code>noFlashingHazard</code></a>, <a href="#unknownFlashingHazard"


### PR DESCRIPTION
Same fix as https://github.com/w3c/epub-specs/pull/2784

One minor additional change is to the order of paragraphs in the flashing hazard definition. I noticed yesterday that the equivalence to wcag is stated before the definition for the value. Every other definition starts with the "Indicates that ..." paragraph.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/pull/229.html" title="Last updated on Aug 28, 2025, 4:05 PM UTC (9365cfd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/229/c60ddd0...9365cfd.html" title="Last updated on Aug 28, 2025, 4:05 PM UTC (9365cfd)">Diff</a>