### PR TITLE
Revert to generic title (proposal)

### DIFF
--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
 	<meta charset="utf-8">
-	<title>Accessibility Properties Crosswalk (schema.org, ONIX, &amp; MARC 21)</title>
+	<title>Accessibility Properties Crosswalk</title>
 	<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 	<script src="../common/js/permalink-a11y.js" class="remove"></script>
 	<script src="../common/js/previousRelease.js" class="remove"></script>


### PR DESCRIPTION
The crosswalk includes references to different accessibility metadata vocabularies and acts as a hub. Therefore, I propose that we revert to the initial generic title rather than attempting to list accessibility vocabularies in brackets.