### PR TITLE
fixes #241

### DIFF
--- a/crosswalk/index.html
+++ b/crosswalk/index.html
@@ -184,7 +184,7 @@
     
     <section id="dc-terms">
 		<h2>Properties from Dublin Core</h2>
-        <h3>Conformance Declarations</h3>
+        <h3>Conformance declarations</h3>
         
 		<p>The following table provides a crosswalk between the properties defined in the <a
 				href="https://www.w3.org/TR/epub-a11y-11">EPUB Accessibility specification</a> [[EPUB-A11Y-11]] and the


### PR DESCRIPTION
This addresses @mattgarrish's issues regarding EPUB properties and separating out DC:Terms and improved organization.

If there is still an issue regarding "the information and resources section looks misplaced at the start of the document. Supplementary info like that is usually a trailing section or appendix. The crosswalk is the most important thing." This can be copied into a new issue.