### PR TITLE
Add version number

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 	<head>
 		<meta charset="utf-8">
-		<title>Schema.org Accessibility Properties for Discoverability Vocabulary</title>
+		<title>Schema.org Accessibility Properties for Discoverability Vocabulary 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="common/js/examples.js" class="remove"></script>
 		<script src="common/js/previousRelease.js" class="remove"></script>
@@ -213,6 +213,23 @@
 						benefit from a new descriptor, the resulting combined value must be registered in the
 						vocabulary.</p>
 				</div>
+			</section>
+
+			<section id="versioning">
+				<h3>Versioning</h3>
+
+				<p>As this vocabulary was initially developed in a web schemas wiki hosted by W3C, for a long time it
+					did not have a version attached to it. To improve reader awareness of when changes to the document
+					occur, a version was added in early 2026.</p>
+
+				<p>Given the history of the document, all updates prior to the first versioned release are considered
+					part of a "1.0" version of the vocabulary. The first versioned document was therefore assigned the
+					value "1.1" and all subsequent releases will increment these numbers as follows:</p>
+
+				<ul>
+					<li>The major number will change whenever new terms are added or existing terms are deprecated.</li>
+					<li>The minor number will change whenever minor definition clarifications or fixes are made.</li>
+				</ul>
 			</section>
 		</section>
 		<section id="accessibilityAPI">


### PR DESCRIPTION
I opted to go with a two-digit number instead of three as I can't think of a scenario in which the vocabulary would change in an incompatible way without it becoming something else entirely. Major and minor fixes are all we're likely to make.

Fixes #258


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/pull/262.html" title="Last updated on Apr 23, 2026, 6:19 PM UTC (86e4d3e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/a11y-discov-vocab/262/f015801...86e4d3e.html" title="Last updated on Apr 23, 2026, 6:19 PM UTC (86e4d3e)">Diff</a>